### PR TITLE
chore(gc): remove unused parameter (nfc)

### DIFF
--- a/passes/GC/Liveness.cpp
+++ b/passes/GC/Liveness.cpp
@@ -61,7 +61,7 @@ std::optional<Liveness> LivenessMap::getLiveness(wasm::Expression *expr) const {
 }
 
 Liveness LivenessMap::getLiveness(size_t const exprIndex) const {
-  Liveness ret{dimension_, invalid_};
+  Liveness ret{dimension_};
   for (size_t const index : Range{dimension_}) {
     ret.setBefore(index, get(static_cast<ssize_t>(exprIndex), Pos::Before, index));
     ret.setAfter(index, get(static_cast<ssize_t>(exprIndex), Pos::After, index));

--- a/passes/GC/Liveness.hpp
+++ b/passes/GC/Liveness.hpp
@@ -19,7 +19,7 @@ class Liveness {
   DynBitset after_;
 
 public:
-  explicit Liveness(size_t size, DynBitset invalid) : before_(size), after_(size) { static_cast<void>(invalid); }
+  explicit Liveness(size_t size) : before_(size), after_(size) {}
   void setBefore(size_t index, bool isLive) { before_.set(index, isLive); }
   void setAfter(size_t index, bool isLive) { after_.set(index, isLive); }
   DynBitset const &before() const { return before_; }


### PR DESCRIPTION
`invalid` in constructor of `Liveness` is never used.
