### PR TITLE
feat(as): optimize `visit_globals` by skipping statis gc obj

### DIFF
--- a/tests/frontend/compiler/assignment-chain.wat
+++ b/tests/frontend/compiler/assignment-chain.wat
@@ -3600,14 +3600,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/call-inferred.wat
+++ b/tests/frontend/compiler/call-inferred.wat
@@ -3631,14 +3631,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 288)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 96)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/call-rest.wat
+++ b/tests/frontend/compiler/call-rest.wat
@@ -4737,18 +4737,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 720)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 176)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/call-super.wat
+++ b/tests/frontend/compiler/call-super.wat
@@ -4123,14 +4123,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 272)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 80)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/class-implements.wat
+++ b/tests/frontend/compiler/class-implements.wat
@@ -5147,14 +5147,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/class-overloading-cast.wat
+++ b/tests/frontend/compiler/class-overloading-cast.wat
@@ -4179,14 +4179,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/class-overloading.wat
+++ b/tests/frontend/compiler/class-overloading.wat
@@ -5180,14 +5180,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 256)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 64)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/class-override.wat
+++ b/tests/frontend/compiler/class-override.wat
@@ -3550,14 +3550,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/class.wat
+++ b/tests/frontend/compiler/class.wat
@@ -3762,18 +3762,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 432)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/constructor.wat
+++ b/tests/frontend/compiler/constructor.wat
@@ -4101,14 +4101,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/do.wat
+++ b/tests/frontend/compiler/do.wat
@@ -4351,14 +4351,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 256)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 64)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/duplicate-fields.wat
+++ b/tests/frontend/compiler/duplicate-fields.wat
@@ -3784,14 +3784,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/empty-exportruntime.wat
+++ b/tests/frontend/compiler/empty-exportruntime.wat
@@ -3437,22 +3437,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 432)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 496)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/empty-new.wat
+++ b/tests/frontend/compiler/empty-new.wat
@@ -3296,14 +3296,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/exportstar-rereexport.wat
+++ b/tests/frontend/compiler/exportstar-rereexport.wat
@@ -3605,14 +3605,6 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 272)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 80)
-   (local.get $0)
-  )
   (if
    (local.tee $1
     (global.get $rereexport/car)

--- a/tests/frontend/compiler/extends-baseaggregate.wat
+++ b/tests/frontend/compiler/extends-baseaggregate.wat
@@ -3807,18 +3807,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 384)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 592)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 192)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/extends-recursive.wat
+++ b/tests/frontend/compiler/extends-recursive.wat
@@ -3367,14 +3367,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/extension/utf8_const_str.wat
+++ b/tests/frontend/compiler/extension/utf8_const_str.wat
@@ -4007,14 +4007,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 384)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 192)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/field-initialization.wat
+++ b/tests/frontend/compiler/field-initialization.wat
@@ -5719,18 +5719,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 512)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/field.wat
+++ b/tests/frontend/compiler/field.wat
@@ -3631,14 +3631,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/for.wat
+++ b/tests/frontend/compiler/for.wat
@@ -4362,14 +4362,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 256)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 64)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/function-call.wat
+++ b/tests/frontend/compiler/function-call.wat
@@ -3585,14 +3585,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 448)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 256)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/function-expression.wat
+++ b/tests/frontend/compiler/function-expression.wat
@@ -4061,14 +4061,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 768)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 576)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/getter-call.wat
+++ b/tests/frontend/compiler/getter-call.wat
@@ -3343,14 +3343,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/incremental-gc/call-indirect.wat
+++ b/tests/frontend/compiler/incremental-gc/call-indirect.wat
@@ -3524,14 +3524,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 160)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 368)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/infer-array.wat
+++ b/tests/frontend/compiler/infer-array.wat
@@ -5201,22 +5201,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 256)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 720)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1024)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 64)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/infer-generic.wat
+++ b/tests/frontend/compiler/infer-generic.wat
@@ -3687,14 +3687,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 400)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 208)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/inlining.wat
+++ b/tests/frontend/compiler/inlining.wat
@@ -4176,14 +4176,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 304)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 112)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/instanceof.wat
+++ b/tests/frontend/compiler/instanceof.wat
@@ -8194,14 +8194,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/issues/1095.wat
+++ b/tests/frontend/compiler/issues/1095.wat
@@ -3504,14 +3504,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/issues/1225.wat
+++ b/tests/frontend/compiler/issues/1225.wat
@@ -3514,14 +3514,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/issues/1699.wat
+++ b/tests/frontend/compiler/issues/1699.wat
@@ -4111,22 +4111,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 320)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 528)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 128)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/issues/2166.wat
+++ b/tests/frontend/compiler/issues/2166.wat
@@ -3707,14 +3707,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/issues/2322/index.wat
+++ b/tests/frontend/compiler/issues/2322/index.wat
@@ -3319,14 +3319,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/issues/2622.wat
+++ b/tests/frontend/compiler/issues/2622.wat
@@ -3407,14 +3407,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
   (if
    (local.tee $1
     (global.get $issues/2622/_a/t1)

--- a/tests/frontend/compiler/issues/2622/_a.wat
+++ b/tests/frontend/compiler/issues/2622/_a.wat
@@ -3363,14 +3363,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/issues/2707.wat
+++ b/tests/frontend/compiler/issues/2707.wat
@@ -3498,14 +3498,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 304)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 112)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/issues/2873.wat
+++ b/tests/frontend/compiler/issues/2873.wat
@@ -7082,14 +7082,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1760)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1568)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/logical.wat
+++ b/tests/frontend/compiler/logical.wat
@@ -4091,14 +4091,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 272)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 80)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/managed-cast.wat
+++ b/tests/frontend/compiler/managed-cast.wat
@@ -3758,14 +3758,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/new.wat
+++ b/tests/frontend/compiler/new.wat
@@ -3575,14 +3575,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/number.wat
+++ b/tests/frontend/compiler/number.wat
@@ -7827,22 +7827,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 448)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 256)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1056)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 2112)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/object-literal.wat
+++ b/tests/frontend/compiler/object-literal.wat
@@ -5191,14 +5191,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 176)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 288)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/operator-overload-non-ambiguity.wat
+++ b/tests/frontend/compiler/operator-overload-non-ambiguity.wat
@@ -3511,14 +3511,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/optional-typeparameters.wat
+++ b/tests/frontend/compiler/optional-typeparameters.wat
@@ -3568,14 +3568,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/reexport.wat
+++ b/tests/frontend/compiler/reexport.wat
@@ -3491,14 +3491,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 272)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 80)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/rereexport.wat
+++ b/tests/frontend/compiler/rereexport.wat
@@ -3624,14 +3624,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 272)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 80)
-   (local.get $0)
-  )
   (if
    (local.tee $1
     (global.get $reexport/car)

--- a/tests/frontend/compiler/resolve-access.wat
+++ b/tests/frontend/compiler/resolve-access.wat
@@ -4973,22 +4973,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 256)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 64)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1136)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 2192)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/resolve-binary.wat
+++ b/tests/frontend/compiler/resolve-binary.wat
@@ -10218,22 +10218,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 576)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 384)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1184)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 2240)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/resolve-elementaccess.wat
+++ b/tests/frontend/compiler/resolve-elementaccess.wat
@@ -7300,26 +7300,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 336)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 144)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 2544)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 3600)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/resolve-function-expression.wat
+++ b/tests/frontend/compiler/resolve-function-expression.wat
@@ -4517,22 +4517,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 624)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 432)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1232)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 2288)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/resolve-new.wat
+++ b/tests/frontend/compiler/resolve-new.wat
@@ -3362,14 +3362,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/resolve-propertyaccess.wat
+++ b/tests/frontend/compiler/resolve-propertyaccess.wat
@@ -4781,22 +4781,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 448)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 256)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1056)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 2112)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/resolve-ternary.wat
+++ b/tests/frontend/compiler/resolve-ternary.wat
@@ -6747,22 +6747,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 448)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 256)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1056)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 2112)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/resolve-unary.wat
+++ b/tests/frontend/compiler/resolve-unary.wat
@@ -5231,22 +5231,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 448)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 256)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1056)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 2112)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/return-unreachable.wat
+++ b/tests/frontend/compiler/return-unreachable.wat
@@ -3509,18 +3509,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 320)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 128)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/rt/finalize.wat
+++ b/tests/frontend/compiler/rt/finalize.wat
@@ -3459,14 +3459,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/rt/issue-2719.wat
+++ b/tests/frontend/compiler/rt/issue-2719.wat
@@ -3477,14 +3477,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/rt/runtime-incremental-export.wat
+++ b/tests/frontend/compiler/rt/runtime-incremental-export.wat
@@ -3437,22 +3437,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 432)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 496)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/array-literal.wat
+++ b/tests/frontend/compiler/std/array-literal.wat
@@ -5006,18 +5006,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 176)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 784)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 448)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/array.wat
+++ b/tests/frontend/compiler/std/array.wat
@@ -50051,34 +50051,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 320)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1616)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 5392)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 128)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 7120)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 8176)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/arraybuffer.wat
+++ b/tests/frontend/compiler/std/arraybuffer.wat
@@ -4915,18 +4915,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 336)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 144)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/dataview.wat
+++ b/tests/frontend/compiler/std/dataview.wat
@@ -7663,18 +7663,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 336)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 144)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/date.wat
+++ b/tests/frontend/compiler/std/date.wat
@@ -15813,34 +15813,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 368)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 5760)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 5808)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 176)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1280)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 2336)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/map.wat
+++ b/tests/frontend/compiler/std/map.wat
@@ -32085,22 +32085,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 432)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 592)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/new.wat
+++ b/tests/frontend/compiler/std/new.wat
@@ -3379,14 +3379,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/object.wat
+++ b/tests/frontend/compiler/std/object.wat
@@ -4799,14 +4799,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 400)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 208)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/operator-overloading.wat
+++ b/tests/frontend/compiler/std/operator-overloading.wat
@@ -7590,14 +7590,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/set.wat
+++ b/tests/frontend/compiler/std/set.wat
@@ -22248,18 +22248,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 432)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/static-array.wat
+++ b/tests/frontend/compiler/std/static-array.wat
@@ -4592,18 +4592,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 448)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 560)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 608)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/staticarray.wat
+++ b/tests/frontend/compiler/std/staticarray.wat
@@ -11761,22 +11761,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 64)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 656)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1312)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 320)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/string-casemapping.wat
+++ b/tests/frontend/compiler/std/string-casemapping.wat
@@ -9143,22 +9143,6 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 256)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 64)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 18608)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 19664)
-   (local.get $0)
-  )
   (if
    (local.tee $1
     (global.get $~lib/util/casemap/SPECIALS_UPPER)

--- a/tests/frontend/compiler/std/string-encoding.wat
+++ b/tests/frontend/compiler/std/string-encoding.wat
@@ -6589,18 +6589,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 320)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 128)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 688)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/string.wat
+++ b/tests/frontend/compiler/std/string.wat
@@ -30933,30 +30933,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 240)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 13040)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 14688)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 352)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 15616)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 16672)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/symbol.wat
+++ b/tests/frontend/compiler/std/symbol.wat
@@ -6507,22 +6507,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 304)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 512)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 624)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 112)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/typedarray.wat
+++ b/tests/frontend/compiler/std/typedarray.wat
@@ -97708,26 +97708,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 336)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 144)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 7408)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 8464)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/std/uri.wat
+++ b/tests/frontend/compiler/std/uri.wat
@@ -6162,18 +6162,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 352)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 160)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 560)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/super-inline.wat
+++ b/tests/frontend/compiler/super-inline.wat
@@ -3460,14 +3460,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 224)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 32)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/switch.wat
+++ b/tests/frontend/compiler/switch.wat
@@ -6313,14 +6313,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 496)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 304)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/templateliteral.wat
+++ b/tests/frontend/compiler/templateliteral.wat
@@ -8152,22 +8152,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 384)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 192)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 1440)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 2496)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/throw.wat
+++ b/tests/frontend/compiler/throw.wat
@@ -2553,10 +2553,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 464)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/typeof.wat
+++ b/tests/frontend/compiler/typeof.wat
@@ -4143,14 +4143,6 @@
     )
    )
   )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 528)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 336)
-   (local.get $0)
-  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/while.wat
+++ b/tests/frontend/compiler/while.wat
@@ -4583,14 +4583,7 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (call $~lib/rt/itcms/__visit
-   (i32.const 272)
-   (local.get $0)
-  )
-  (call $~lib/rt/itcms/__visit
-   (i32.const 80)
-   (local.get $0)
-  )
+  (nop)
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)


### PR DESCRIPTION
static GC objects don't have any reference children, therefore, there is no need to visit it in `visit_globals`
