### PR TITLE
feat(driver): basic implement for `build.ts` concept [1/N]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ else()
 endif()
 
 add_subdirectory(common)
+add_subdirectory(driver)
 add_subdirectory(frontend)
 add_subdirectory(passes)
 add_subdirectory(support)

--- a/driver/BuildScript.cpp
+++ b/driver/BuildScript.cpp
@@ -1,0 +1,70 @@
+// Copyright (C) 2025 wasm-ecosystem
+// SPDX-License-Identifier: Apache-2.0
+
+#include <filesystem>
+#include <fmt/base.h>
+#include <memory>
+
+#include "BuildScript.hpp"
+#include "warp_runner/WarpRunner.hpp"
+#include "warpo/frontend/Compiler.hpp"
+#include "warpo/frontend/LinkedAPIAssemblyscript.hpp"
+#include "warpo/passes/Runner.hpp"
+#include "warpo/support/Container.hpp"
+#include "warpo/support/FileSystem.hpp"
+#include "warpo/support/Opt.hpp"
+
+#include "src/core/common/NativeSymbol.hpp"
+#include "src/core/common/Span.hpp"
+
+namespace warpo::driver {
+
+static cli::Opt<std::filesystem::path> projectOption{
+    cli::Category::All,
+    "-p",
+    "--project",
+    [](argparse::Argument &arg) -> void {
+      arg.help("Compile the project given the path to its configuration file, or to a folder with a 'build.ts'")
+          .nargs(1U)
+          .default_value("");
+    },
+};
+
+static std::filesystem::path getProjectConfigPath() {
+  std::filesystem::path projectPath = projectOption.get();
+  if (projectPath.empty()) {
+    return std::filesystem::current_path() / "build.ts";
+  }
+  if (isDirectory(projectPath)) {
+    return projectPath / "build.ts";
+  }
+  return projectPath;
+}
+
+} // namespace warpo::driver
+
+std::unique_ptr<WarpRunner> warpo::driver::initProjectConfig() {
+  frontend::Config frontendConfig = frontend::getDefaultConfig();
+  frontendConfig.emitDebugLine = true;
+
+  std::filesystem::path const buildScriptPath = getProjectConfigPath();
+  if (!isRegularFile(buildScriptPath))
+    return nullptr;
+  frontend::CompilationResult const result = frontend::compile({buildScriptPath}, frontendConfig);
+  if (result.m.invalid()) {
+    fmt::println("compilation failed");
+    fmt::println("{}", result.errorMessage);
+    throw std::runtime_error("compilation 'build.ts' failed");
+  }
+  passes::Config const passesConfig{.sourceMapURL = ""};
+  passes::Output output = passes::runOnModule(result.m, passesConfig);
+
+  std::unique_ptr<WarpRunner> r{new WarpRunner(nullptr)};
+  std::vector<vb::NativeSymbol> linkedAPI;
+  append(linkedAPI, frontend::createAssemblyscriptAPI());
+  (*r)->initFromBytecode(vb::Span<uint8_t const>{output.wasm.data(), output.wasm.size()},
+                         vb::Span<vb::NativeSymbol const>(linkedAPI.data(), linkedAPI.size()), false);
+  uint8_t const *const stackTop = (*r).getStackTop();
+  (*r)->start(stackTop);
+  return r;
+}

--- a/driver/BuildScript.hpp
+++ b/driver/BuildScript.hpp
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 wasm-ecosystem
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+
+#include "warp_runner/WarpRunner.hpp"
+
+#pragma once
+
+namespace warpo::driver {
+
+std::unique_ptr<WarpRunner> initProjectConfig();
+
+}

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -1,0 +1,11 @@
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} warpo_driver_sources)
+
+add_library(warpo_driver ${warpo_driver_sources})
+
+target_link_libraries(warpo_driver
+    PRIVATE warpo_frontend warpo_passes warp_runner
+    PUBLIC binaryen fmt::fmt warpo_common
+)
+target_include_directories(warpo_driver
+    PUBLIC "${PROJECT_SOURCE_DIR}/include"
+)

--- a/driver/Driver.cpp
+++ b/driver/Driver.cpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 wasm-ecosystem
+// SPDX-License-Identifier: Apache-2.0
+
+#include <filesystem>
+#include <fmt/base.h>
+
+#include "BuildScript.hpp"
+#include "warpo/driver/Driver.hpp"
+#include "warpo/frontend/Compiler.hpp"
+#include "warpo/passes/Runner.hpp"
+#include "warpo/support/Opt.hpp"
+
+namespace warpo::driver {
+
+static cli::Opt<std::filesystem::path> outputPath{
+    cli::Category::All,
+    "-o",
+    "--output",
+    [](argparse::Argument &arg) -> void { arg.help("output file").required(); },
+};
+
+} // namespace warpo::driver
+
+void warpo::driver::build() {
+  initProjectConfig();
+
+  frontend::CompilationResult const result = frontend::compile();
+  if (result.m.invalid()) {
+    fmt::println("compilation failed");
+    fmt::println("{}", result.errorMessage);
+    throw std::runtime_error("compilation failed");
+  }
+  passes::runAndEmit(result.m, outputPath.get());
+}

--- a/frontend/CompilerImpl.hpp
+++ b/frontend/CompilerImpl.hpp
@@ -18,7 +18,7 @@
 #include <string_view>
 #include <vector>
 
-#include "warp_runner/warpRunner.hpp"
+#include "warp_runner/WarpRunner.hpp"
 #include "warpo/common/AsModule.hpp"
 #include "warpo/frontend/Compiler.hpp"
 

--- a/frontend/LinkedAPI.cpp
+++ b/frontend/LinkedAPI.cpp
@@ -3,14 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cassert>
-#include <cstddef>
 #include <cstdlib>
 #include <cstring>
 #include <fmt/base.h>
 #include <vector>
 
 #include "LinkedAPI.hpp"
-#include "warpo/common/VariableInfo.hpp"
+#include "warpo/frontend/LinkedAPIAssemblyscript.hpp"
 #include "warpo/support/Container.hpp"
 
 #include "src/core/common/NativeSymbol.hpp"

--- a/frontend/LinkedAPI.hpp
+++ b/frontend/LinkedAPI.hpp
@@ -10,7 +10,6 @@
 
 namespace warpo::frontend {
 
-std::vector<vb::NativeSymbol> createAssemblyscriptAPI();
 std::vector<vb::NativeSymbol> createBinaryenLinkedAPI();
 std::vector<vb::NativeSymbol> createCppWrapperAPI();
 std::vector<vb::NativeSymbol> createOptAPI();

--- a/frontend/LinkedAPIAssemblyscript.cpp
+++ b/frontend/LinkedAPIAssemblyscript.cpp
@@ -14,7 +14,7 @@
 #include <vector>
 
 #include "AsString.hpp"
-#include "LinkedAPI.hpp"
+#include "warpo/frontend/LinkedAPIAssemblyscript.hpp"
 
 #include "src/WasmModule/WasmModule.hpp"
 #include "src/core/common/NativeSymbol.hpp"

--- a/include/warpo/driver/Driver.hpp
+++ b/include/warpo/driver/Driver.hpp
@@ -1,0 +1,10 @@
+// Copyright (C) 2025 wasm-ecosystem
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace warpo::driver {
+
+void build();
+
+} // namespace warpo::driver

--- a/include/warpo/frontend/LinkedAPIAssemblyscript.hpp
+++ b/include/warpo/frontend/LinkedAPIAssemblyscript.hpp
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 wasm-ecosystem
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+
+#include "src/core/common/NativeSymbol.hpp"
+
+namespace warpo::frontend {
+
+std::vector<vb::NativeSymbol> createAssemblyscriptAPI();
+
+}

--- a/include/warpo/passes/Runner.hpp
+++ b/include/warpo/passes/Runner.hpp
@@ -26,6 +26,8 @@ struct Config {
 
 void init();
 
+void lowering(AsModule const &m);
+
 Output runOnWat(std::string const &input, Config const &config);
 Output runOnModule(AsModule const &m, Config const &config);
 

--- a/include/warpo/support/FileSystem.hpp
+++ b/include/warpo/support/FileSystem.hpp
@@ -21,4 +21,7 @@ std::string readBinaryFile(std::string const &path);
 
 void writeBinaryFile(std::string const &path, std::string data);
 
+bool isDirectory(const std::filesystem::path &path);
+bool isRegularFile(std::filesystem::path const &path);
+
 } // namespace warpo

--- a/support/FileSystem.cpp
+++ b/support/FileSystem.cpp
@@ -67,6 +67,10 @@ void warpo::writeBinaryFile(std::string const &path, std::string data) {
   out << data;
 }
 
+bool warpo::isDirectory(std::filesystem::path const &path) { return std::filesystem::is_directory(path); }
+
+bool warpo::isRegularFile(std::filesystem::path const &path) { return std::filesystem::is_regular_file(path); }
+
 #ifdef WARPO_ENABLE_UNIT_TESTS
 
 #include <gtest/gtest.h>

--- a/tests/frontend/CMakeLists.txt
+++ b/tests/frontend/CMakeLists.txt
@@ -5,6 +5,4 @@ target_link_libraries(warpo_frontend_test
 )
 target_include_directories(warpo_frontend_test
   SYSTEM PRIVATE "${PROJECT_SOURCE_DIR}/third_party/binaryen/src"
-  PRIVATE "${PROJECT_SOURCE_DIR}"
-  PRIVATE "${PROJECT_SOURCE_DIR}/frontend"
 )

--- a/tests/frontend/FrontendTest.cpp
+++ b/tests/frontend/FrontendTest.cpp
@@ -15,7 +15,6 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <pass.h>
-#include <passes/GC/OptLower.hpp>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -25,9 +24,10 @@
 #include <vector>
 #include <wasm-binary.h>
 
-#include "LinkedAPI.hpp"
-#include "warp_runner/warpRunner.hpp"
+#include "warp_runner/WarpRunner.hpp"
 #include "warpo/frontend/Compiler.hpp"
+#include "warpo/frontend/LinkedAPIAssemblyscript.hpp"
+#include "warpo/passes/Runner.hpp"
 #include "warpo/support/FileSystem.hpp"
 #include "warpo/support/Opt.hpp"
 #include "wasm-validator.h"
@@ -126,9 +126,7 @@ frontend::CompilationResult compile(TestConfigJson const &configJson, std::files
     return TestResult::Skip;
 
   // lowering built-in imports
-  wasm::PassRunner passRunner{asModule.get()};
-  passRunner.add(std::unique_ptr<wasm::Pass>{new passes::gc::OptLower()});
-  passRunner.run();
+  passes::lowering(asModule);
   wasm::BufferWithRandomAccess buffer;
   wasm::WasmBinaryWriter writer(asModule.get(), buffer, wasm::PassOptions::getWithoutOptimization());
   writer.setNamesSection(false);

--- a/tools/asc/AscMain.cpp
+++ b/tools/asc/AscMain.cpp
@@ -7,23 +7,17 @@
 #include <cstdlib>
 #include <cstring>
 #include <exception>
-#include <filesystem>
 #include <fmt/base.h>
 #include <fmt/format.h>
 #include <string>
 
+#include "warpo/driver/Driver.hpp"
 #include "warpo/frontend/Compiler.hpp"
 #include "warpo/passes/Runner.hpp"
 #include "warpo/support/Opt.hpp"
 
 namespace warpo {
 
-static cli::Opt<std::filesystem::path> outputPath{
-    cli::Category::All,
-    "-o",
-    "--output",
-    [](argparse::Argument &arg) -> void { arg.help("output file").required(); },
-};
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)
 void ascMain(int argc, const char *argv[]) {
   frontend::init();
@@ -31,13 +25,7 @@ void ascMain(int argc, const char *argv[]) {
   argparse::ArgumentParser program("warpo_asc", "git@" GIT_COMMIT);
   cli::init(cli::Category::Frontend | cli::Category::Transformation | cli::Category::Optimization, program, argc, argv);
 
-  frontend::CompilationResult const result = frontend::compile();
-  if (result.m.invalid()) {
-    fmt::println("compilation failed");
-    fmt::println("{}", result.errorMessage);
-    throw std::runtime_error("compilation failed");
-  }
-  passes::runAndEmit(result.m, outputPath.get());
+  driver::build();
 }
 
 } // namespace warpo

--- a/tools/asc/CMakeLists.txt
+++ b/tools/asc/CMakeLists.txt
@@ -3,7 +3,7 @@ aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} sources)
 add_executable(warpo_asc ${sources})
 
 target_link_libraries(warpo_asc
-    PUBLIC warpo_frontend warpo_passes
+    PUBLIC warpo_driver
 )
 target_include_directories(
     warpo_asc


### PR DESCRIPTION
This PR introduce a new module named warpo_driver. 
It is abstract layer between executable and frontend/passes.
It focus on
1. control the whole compilation process
2. handle the input / output

[1/N] of #67 