### PR TITLE
fix(trace_visualizer): add volatile to avoid optimization

### DIFF
--- a/tools/trace_visualizer/Main.cpp
+++ b/tools/trace_visualizer/Main.cpp
@@ -55,7 +55,7 @@ static uint64_t getCurrentCPUCounterImpl() { throw std::runtime_error("Not imple
 
 #if defined(__x86_64__)
 #if defined(__clang__) || defined(__GNUC__)
-static uint64_t getCurrentCPUCounterImpl() { std::return static_cast<uint64_t>(__rdtsc()); }
+static uint64_t getCurrentCPUCounterImpl() { return static_cast<uint64_t>(__rdtsc()); }
 #endif
 #elif defined(_MSC_VER)
 static uint64_t getCurrentCPUCounterImpl() { return static_cast<uint64_t>(__rdtsc()); }


### PR DESCRIPTION
Fixed: #126
In release build, optimizer will inline `getCurrentCPUCounter` and opt them.
It will cause divide zero when calculating rate.
Finally the timestamp will be wrong.