### PR TITLE
fix(as): give correct precedence for type assert expr

### DIFF
--- a/assemblyscript/src/parser.ts
+++ b/assemblyscript/src/parser.ts
@@ -3154,7 +3154,7 @@ export class Parser extends DiagnosticEmitter {
           this.error(DiagnosticCode._0_expected, tn.range(), ">");
           return null;
         }
-        let expr = this.parseExpression(tn, Precedence.Call);
+        let expr = this.parseExpression(tn, Precedence.TypeAssert);
         if (!expr) return null;
         return Node.createAssertionExpression(AssertionKind.Prefix, expr, toType, tn.range(startPos, tn.pos));
       }
@@ -3654,9 +3654,9 @@ export const enum Precedence {
   Additive,
   Multiplicative,
   Exponentiated,
+  TypeAssert,
   UnaryPrefix,
   UnaryPostfix,
-  Call,
   MemberAccess,
   Grouping,
 }

--- a/tests/frontend/compiler/type-cast.opt.wat
+++ b/tests/frontend/compiler/type-cast.opt.wat
@@ -1,0 +1,6 @@
+(module
+ (memory $0 1)
+ (data $0 (i32.const 12) ",")
+ (data $0.1 (i32.const 24) "\02\00\00\00\18\00\00\00t\00y\00p\00e\00-\00c\00a\00s\00t\00.\00t\00s")
+ (export "memory" (memory $0))
+)

--- a/tests/frontend/compiler/type-cast.ts
+++ b/tests/frontend/compiler/type-cast.ts
@@ -1,0 +1,21 @@
+function typecast(): void {
+  let a: u32 = 256;
+  let b: u8 = <u8>a;
+  assert(b == 0);
+}
+typecast();
+
+function typpecastWithUnaryPrefix(): void {
+  let a: i32 = -100;
+  let b: i8 = <i8>-a;
+  assert(b == 100);
+}
+typpecastWithUnaryPrefix();
+
+function typpecastWithUnaryPostfix(): void {
+  let a: i32 = 127;
+  let b: i8 = <i8>a++;
+  assert(a == 128);
+  assert(b == 127);
+}
+typpecastWithUnaryPostfix();

--- a/tests/frontend/compiler/type-cast.wat
+++ b/tests/frontend/compiler/type-cast.wat
@@ -1,0 +1,144 @@
+(module
+ (type $0 (func))
+ (type $1 (func (param i32) (result i32)))
+ (type $2 (func (param i32 i32 i32 i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
+ (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
+ (global $~lib/memory/__data_end i32 (i32.const 60))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 32828))
+ (global $~lib/memory/__heap_base i32 (i32.const 32828))
+ (memory $0 1)
+ (data $0 (i32.const 12) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\18\00\00\00t\00y\00p\00e\00-\00c\00a\00s\00t\00.\00t\00s\00\00\00\00\00")
+ (table $0 1 1 funcref)
+ (elem $0 (i32.const 1))
+ (export "memory" (memory $0))
+ (start $~start)
+ (func $type-cast/typecast
+  (local $a i32)
+  (local $b i32)
+  (local.set $a
+   (i32.const 256)
+  )
+  (local.set $b
+   (local.get $a)
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (i32.and
+      (local.get $b)
+      (i32.const 255)
+     )
+     (i32.const 0)
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 32)
+     (i32.const 4)
+     (i32.const 3)
+    )
+    (unreachable)
+   )
+  )
+ )
+ (func $type-cast/typpecastWithUnaryPrefix
+  (local $a i32)
+  (local $b i32)
+  (local.set $a
+   (i32.const -100)
+  )
+  (local.set $b
+   (i32.sub
+    (i32.const 0)
+    (local.get $a)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (i32.extend8_s
+      (local.get $b)
+     )
+     (i32.const 100)
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 32)
+     (i32.const 11)
+     (i32.const 3)
+    )
+    (unreachable)
+   )
+  )
+ )
+ (func $type-cast/typpecastWithUnaryPostfix
+  (local $a i32)
+  (local $1 i32)
+  (local $b i32)
+  (local.set $a
+   (i32.const 127)
+  )
+  (local.set $b
+   (block (result i32)
+    (local.set $a
+     (i32.add
+      (local.tee $1
+       (local.get $a)
+      )
+      (i32.const 1)
+     )
+    )
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (local.get $a)
+     (i32.const 128)
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 32)
+     (i32.const 18)
+     (i32.const 3)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (i32.extend8_s
+      (local.get $b)
+     )
+     (i32.const 127)
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 32)
+     (i32.const 19)
+     (i32.const 3)
+    )
+    (unreachable)
+   )
+  )
+ )
+ (func $start:type-cast
+  (call $type-cast/typecast)
+  (call $type-cast/typpecastWithUnaryPrefix)
+  (call $type-cast/typpecastWithUnaryPostfix)
+ )
+ (func $~start
+  (call $start:type-cast)
+ )
+)


### PR DESCRIPTION
From `https://ts-ast-viewer.com/`, precedence order is: `AsteriskToken` > `TypeAssertion` > `PostfixUnary`.

```ts
<number>a * 1;
<number>a++;
```
```
BinaryExpression
  TypeAssertionExpression
    NumberKeyword
    Identifier
  AsteriskToken
  NumericLiteral

TypeAssertionExpression
  NumberKeyword
  PostfixUnaryExpression
    Identifier
```

In this PR, we rename the `Precedence.Call` with `Precedence.TypeAssert` for better match actual AST nodes.
And changing the order of `Precedence` to ensure postfix operator combine with subexpr easier than type assert operator.