### PR TITLE
chore(diagnostic): use name range in error message

### DIFF
--- a/assemblyscript/src/compiler.ts
+++ b/assemblyscript/src/compiler.ts
@@ -1209,7 +1209,7 @@ export class Compiler extends DiagnosticEmitter {
       }
 
       // Importing mutable globals is not supported in the MVP
-      this.error(DiagnosticCode.Feature_0_is_not_enabled, global._declaration.range, "mutable-globals");
+      this.error(DiagnosticCode.Feature_0_is_not_enabled, global.nameRange, "mutable-globals");
       global.set(CommonFlags.Errored);
       pendingElements.delete(global);
       return false;
@@ -1408,7 +1408,7 @@ export class Compiler extends DiagnosticEmitter {
               if (element.is(CommonFlags.Const)) {
                 this.error(
                   DiagnosticCode.In_const_enum_declarations_member_initializer_must_be_constant_expression,
-                  member._declaration.range
+                  member.nameRange
                 );
               }
               initInStart = true;
@@ -1748,7 +1748,7 @@ export class Compiler extends DiagnosticEmitter {
       if (classInstance.base && !classInstance.prototype.implicitlyExtendsObject && !flow.is(FlowFlags.CallsSuper)) {
         this.error(
           DiagnosticCode.Constructors_for_derived_classes_must_contain_a_super_call,
-          instance.prototype._declaration.range
+          instance.prototype.nameRange
         );
       }
 
@@ -2286,12 +2286,7 @@ export class Compiler extends DiagnosticEmitter {
     let name = statement.name.text;
     let existedTypeAlias = flow.lookupScopedTypeAlias(name);
     if (existedTypeAlias) {
-      this.errorRelated(
-        DiagnosticCode.Duplicate_identifier_0,
-        statement.range,
-        existedTypeAlias._declaration.range,
-        name
-      );
+      this.errorRelated(DiagnosticCode.Duplicate_identifier_0, statement.range, existedTypeAlias.nameRange, name);
       return this.module.unreachable();
     }
     let element = new TypeDefinition(name, flow.targetFunction, statement, DecoratorFlags.None);
@@ -2995,7 +2990,7 @@ export class Compiler extends DiagnosticEmitter {
           // here: not top-level
           let existingLocal = flow.getScopedLocal(name);
           if (existingLocal) {
-            if (!existingLocal._declaration.range.source.isNative) {
+            if (!existingLocal.nameRange.source.isNative) {
               this.errorRelated(
                 DiagnosticCode.Duplicate_identifier_0,
                 declaration.name.range,
@@ -7004,7 +6999,7 @@ export class Compiler extends DiagnosticEmitter {
       let fname = instance.name;
       let existingLocal = flow.getScopedLocal(fname);
       if (existingLocal) {
-        if (!existingLocal._declaration.range.source.isNative) {
+        if (!existingLocal.nameRange.source.isNative) {
           this.errorRelated(
             DiagnosticCode.Duplicate_identifier_0,
             declaration.name.range,

--- a/assemblyscript/src/flow.ts
+++ b/assemblyscript/src/flow.ts
@@ -440,7 +440,7 @@ export class Flow {
     } else if (scopedLocals.has(name)) {
       let existingLocal = assert(scopedLocals.get(name));
       if (reportNode) {
-        if (!existingLocal._declaration.range.source.isNative) {
+        if (!existingLocal.nameRange.source.isNative) {
           this.program.errorRelated(
             DiagnosticCode.Duplicate_identifier_0,
             reportNode.range,

--- a/assemblyscript/src/program.ts
+++ b/assemblyscript/src/program.ts
@@ -2520,7 +2520,7 @@ export class Program extends DiagnosticEmitter {
           this.errorRelated(
             DiagnosticCode.Duplicate_identifier_0,
             declaration.nameRange,
-            existing._declaration.nameRange,
+            existing.nameRange,
             "default"
           );
           return;
@@ -3178,7 +3178,7 @@ export abstract class DeclaredElement extends Element {
 
   /** Tests if this element is a library element. */
   get isDeclaredInLibrary(): bool {
-    return this._declaration.range.source.isLibrary;
+    return this.nameRange.source.isLibrary;
   }
 
   /** Gets the assiciated decorator nodes. */
@@ -4428,7 +4428,7 @@ export class ClassPrototype extends DeclaredElement {
           this.program.errorRelated(
             DiagnosticCode.Duplicate_identifier_0,
             element.nameRange,
-            (<DeclaredElement>existing)._declaration.nameRange,
+            (<DeclaredElement>existing).nameRange,
             element.name
           );
         } else {

--- a/assemblyscript/src/resolver.ts
+++ b/assemblyscript/src/resolver.ts
@@ -1119,7 +1119,7 @@ export class Resolver extends DiagnosticEmitter {
           this.errorRelated(
             DiagnosticCode.Property_0_only_has_a_setter_and_is_missing_a_getter,
             targetNode.range,
-            setterInstance._declaration.range,
+            setterInstance.nameRange,
             propertyInstance.name
           );
           return null;
@@ -3314,7 +3314,7 @@ export class Resolver extends DiagnosticEmitter {
         }
       } else {
         if (reportMode == ReportMode.Report) {
-          this.error(DiagnosticCode.Duplicate_decorator, operatorInstance._declaration.range);
+          this.error(DiagnosticCode.Duplicate_decorator, operatorInstance.nameRange);
         }
       }
     }


### PR DESCRIPTION
old diagnostic error message depends on `_declaration` only for range information. It will break abstract layer (we need to maintain AST node always).
In the future, we want to limit the usage of AST node in Element.
This pr use abstracted name range for diagnose.

---

**Stack**:
- #190 ⬅
- #189
- #188


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*