### PR TITLE
fix(as): check native source correctly

### DIFF
--- a/assemblyscript/src/ast.ts
+++ b/assemblyscript/src/ast.ts
@@ -1515,6 +1515,10 @@ export class Source extends Node {
       Source._native = source = new Source(SourceKind.LibraryEntry, LIBRARY_PREFIX + "native.ts", "[native code]");
     return source;
   }
+  /** Checks if this source represents native code. */
+  get isNative(): bool {
+    return this == Source._native;
+  }
   private static _native: Source | null = null;
 
   constructor(
@@ -1543,11 +1547,6 @@ export class Source extends Node {
   debugInfoIndex: i32 = -1;
   /** Re-exported sources. */
   exportPaths: string[] | null = null;
-
-  /** Checks if this source represents native code. */
-  get isNative(): bool {
-    return this.internalPath == LIBRARY_SUBST;
-  }
 
   /** Checks if this source is part of the (standard) library. */
   get isLibrary(): bool {

--- a/tests/frontend/compiler/duplicate-identifier.json
+++ b/tests/frontend/compiler/duplicate-identifier.json
@@ -17,6 +17,7 @@
     "var e: i32",
     "TS2300: Duplicate identifier 'f'",
     "let f: f32",
+    "in duplicate-identifier.ts(21,9)",
     "EOF"
   ]
 }


### PR DESCRIPTION
native code's internal  path is `~lib/native.ts` instead of `~lib`. However, it is more easier to check current source is same as static _native field.
