### PR TITLE
feat(ast): add ComputedPropertyName ast node

### DIFF
--- a/assemblyscript/src/compiler.ts
+++ b/assemblyscript/src/compiler.ts
@@ -78,6 +78,7 @@ import {
   IndexSignature,
   File,
   TypeDefinition,
+  CompiledNameNode,
 } from "./program";
 
 import { FlowFlags, Flow, LocalFlags, FieldFlags, ConditionKind } from "./flow";
@@ -6905,7 +6906,7 @@ export class Compiler extends DiagnosticEmitter {
       DecoratorFlags.None,
       declaration.toDeclarationBase(),
       declaration.toFunctionLikeWithBodyBase(),
-      declaration.name,
+      CompiledNameNode.from(declaration.name),
       declaration.identifierAndSignatureRange
     );
     let instance: Function | null;
@@ -8534,7 +8535,7 @@ export class Compiler extends DiagnosticEmitter {
             DecoratorFlags.None,
             declaration.toDeclarationBase(),
             declaration.toFunctionLikeWithBodyBase(),
-            declaration.name,
+            CompiledNameNode.from(declaration.name),
             declaration.identifierAndSignatureRange
           ),
           null,

--- a/assemblyscript/src/diagnosticMessages.json
+++ b/assemblyscript/src/diagnosticMessages.json
@@ -42,7 +42,6 @@
   "Array literal expected.": 227,
   "Function '{0}' is virtual and will not be inlined.": 228,
   "Property '{0}' only has a setter and is missing a getter.": 229,
-  "'{0}' keyword cannot be used here.": 230,
   "A class with a constructor explicitly returning something else than 'this' must be '@final'.": 231,
   "Property '{0}' is always assigned before being used.": 233,
   "Expression does not compile to a value at runtime.": 234,


### PR DESCRIPTION
`ComputedPropertyName` is one of `PropertyName` which can be used as name of class/interface property.
This PR also change the parser to create `ComputedPropertyName`.

commit-id:325557d0

---

**Stack**:
- #205
- #204 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*