### PR TITLE
chore(create): add lazy decorator to avoid FFI in `create.ts`

### DIFF
--- a/create/index.ts
+++ b/create/index.ts
@@ -1,5 +1,8 @@
 import * as api from "./__warpo_create";
 import { __collect } from "rt/index";
 
-__collect(); // trigger GC to ensure the env is loaded.
+__collect();
+
+// @ts-ignore: decorators
+@lazy
 export const __dirname: string = api.getCreateFileDirName();


### PR DESCRIPTION
`__dirname` will init with FFI. It can be saved when `__dirname` does not be used