### PR TITLE
fix(as): detect miss implement getter/setter interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Please follow these instructions after modifying the code.
 
 ## Basic instructions
 
-- When create new **source code** file, add following license header at the beginning of files.
+- When create new **source code** file (exclude `./tests`), add following license header at the beginning of files.
   ```
   // Copyright (C) 2025 wasm-ecosystem
   // SPDX-License-Identifier: Apache-2.0

--- a/assemblyscript/src/program.ts
+++ b/assemblyscript/src/program.ts
@@ -3005,18 +3005,19 @@ export class Program extends DiagnosticEmitter {
     }
     let typeNode = declaration.type;
     if (!typeNode) typeNode = Node.createOmittedType(declaration.name.range.atEnd);
-    this.defineProperty(
-      Node.createMethodDeclaration(
-        declaration.name,
-        declaration.decorators,
-        declaration.flags | CommonFlags.Get,
-        null,
-        Node.createFunctionType([], typeNode, null, false, declaration.range),
-        null,
-        declaration.range
-      ),
-      parent
+    const getterDeclaration = Node.createMethodDeclaration(
+      declaration.name,
+      declaration.decorators,
+      declaration.flags | CommonFlags.Get,
+      null,
+      Node.createFunctionType([], typeNode, null, false, declaration.range),
+      null,
+      declaration.range
     );
+    let property = this.ensureProperty(getterDeclaration, parent);
+    if (!property) return;
+    property.fieldDeclaration = declaration;
+    this.defineProperty(getterDeclaration, parent);
     if (!declaration.is(CommonFlags.Readonly)) {
       this.defineProperty(
         Node.createMethodDeclaration(

--- a/tests/frontend/compiler/interface-getter-setter-errors.json
+++ b/tests/frontend/compiler/interface-getter-setter-errors.json
@@ -1,0 +1,17 @@
+{
+  "stderr": [
+    "ERROR TS2416: Property 'i' in type 'interface-getter-setter-errors/MethodInsteadOfProperty' is not assignable to the same property in base type 'interface-getter-setter-errors/IGetSet'.",
+    "i(): i32 {",
+    "get i(): i32;",
+
+    "ERROR TS2515: Non-abstract class 'interface-getter-setter-errors/B' does not implement inherited abstract member 'get:a' from 'interface-getter-setter-errors/A'.",
+    "class B implements A {",
+    "get a(): string;",
+
+    "ERROR TS2515: Non-abstract class 'interface-getter-setter-errors/WithoutField' does not implement inherited abstract member 'get:a' from 'interface-getter-setter-errors/BaseField'.",
+    "ERROR TS2515: Non-abstract class 'interface-getter-setter-errors/WithoutField' does not implement inherited abstract member 'set:a' from 'interface-getter-setter-errors/BaseField'.",
+
+    "ERROR TS2322: Type '(this: interface-getter-setter-errors/WrongType, ~lib/string/String) => void' is not assignable to type '(this: interface-getter-setter-errors/IGetSet, i32) => void'.",
+    "ERROR TS2322: Type '(this: interface-getter-setter-errors/WrongType) => ~lib/string/String' is not assignable to type '(this: interface-getter-setter-errors/IGetSet) => i32'."
+  ]
+}

--- a/tests/frontend/compiler/interface-getter-setter-errors.ts
+++ b/tests/frontend/compiler/interface-getter-setter-errors.ts
@@ -1,0 +1,37 @@
+export const disableScriptMode = true;
+
+interface IGetSet {
+  get i(): i32;
+  set i(value: i32);
+}
+
+class MethodInsteadOfProperty implements IGetSet {
+  i(): i32 {
+    return 1;
+  }
+}
+
+class WrongType implements IGetSet {
+  get i(): string {
+    return "1";
+  }
+  set i(value: string) {}
+}
+
+let v: IGetSet = new WrongType();
+v.i = 10;
+v.i;
+
+interface A {
+  get a(): string;
+}
+class B implements A {
+  set a(v: string) {}
+}
+new B();
+
+interface BaseField {
+  a: string;
+}
+class WithoutField implements BaseField {}
+new WithoutField();


### PR DESCRIPTION
when interface defines a getter, but class implement it with setter.
it is valid in build time build crash during execution in TS.
we want to throw a error for it.

```ts
interface A {
  get a(): string;
}
class B implements A {
  set a(v: string) {}
}
```
