### PR TITLE
feat(cli): add `--config` and `--project` option from default path

### DIFF
--- a/driver/BuildScript.cpp
+++ b/driver/BuildScript.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <fmt/base.h>
 #include <memory>
+#include <optional>
 
 #include "BuildScript.hpp"
 #include "LinkedAPI.hpp"
@@ -18,10 +19,10 @@
 
 namespace warpo::driver {
 
-static std::filesystem::path getProjectConfigPath() {
+static std::optional<std::filesystem::path> getProjectConfigPath() {
   std::optional<std::filesystem::path> const projectPath = common::ConfigProvider::instance().projectPath();
   if (!projectPath.has_value())
-    return std::filesystem::current_path() / "create.ts";
+    return std::nullopt;
   if (isDirectory(projectPath.value()))
     return projectPath.value() / "create.ts";
   return projectPath.value();
@@ -57,10 +58,10 @@ BuildScriptRunner::BuildScriptRunner(std::filesystem::path const &buildScriptPat
 }
 
 std::unique_ptr<BuildScriptRunner> BuildScriptRunner::create() {
-  std::filesystem::path const buildScriptPath = getProjectConfigPath();
-  if (!isRegularFile(buildScriptPath))
+  std::optional<std::filesystem::path> const buildScriptPath = getProjectConfigPath();
+  if (!buildScriptPath.has_value() || !isRegularFile(*buildScriptPath))
     return nullptr;
-  return std::unique_ptr<BuildScriptRunner>{new BuildScriptRunner(buildScriptPath)};
+  return std::unique_ptr<BuildScriptRunner>{new BuildScriptRunner(*buildScriptPath)};
 }
 
 std::optional<std::filesystem::path> BuildScriptRunner::getPackageRoot(std::string const &packageName) {

--- a/tests/driver/asconfig/run.mjs
+++ b/tests/driver/asconfig/run.mjs
@@ -13,8 +13,6 @@ const projectRoot = __dirname;
 
 const isUpdateMode = argv.includes("--update") || argv.includes("-u");
 
-const configPath = path.join(projectRoot, "asconfig.json");
-
 const targetName = isUpdateMode ? "release-update" : "release";
 const target = asconfig.targets[targetName];
 
@@ -26,7 +24,7 @@ mkdirSync(path.dirname(outputWasm), { recursive: true });
 describe("driver: asconfig", () => {
   it("builds and matches snapshot", { concurrency: false }, async () => {
     const code = await warpoMain({
-      argv: ["build", "--config", configPath, "--target", targetName],
+      argv: ["build", "--target", targetName],
       env,
       cwd: projectRoot,
     });

--- a/tests/driver/module-resolve/run.mjs
+++ b/tests/driver/module-resolve/run.mjs
@@ -20,7 +20,7 @@ const outputWasm = outputWat.replace(/wat$/g, "wasm");
 describe("driver: module-resolve", () => {
   it("builds and matches snapshot", { concurrency: false }, async () => {
     const code = await warpoMain({
-      argv: ["build", "--project", projectRoot, entry, "-o", outputWat],
+      argv: ["build", entry, "-o", outputWat],
       env,
       cwd: projectRoot,
     });


### PR DESCRIPTION
This pull request refines how project and configuration files are detected and passed to the build process, making the build system more robust and user-friendly. The main improvements include updating the logic for finding project config files in C++, enhancing the CLI to automatically supply `--config` and `--project` arguments when appropriate, and simplifying related test cases.