### PR TITLE
chore(typing): fix String.startsWith and String.endsWith typing

### DIFF
--- a/types/std/index.d.ts
+++ b/types/std/index.d.ts
@@ -2253,12 +2253,12 @@ declare class String implements Iterable<string> {
   charCodeAt(index: i32): i32;
   codePointAt(index: i32): i32;
   concat(other: string): string;
-  endsWith(other: string): bool;
+  endsWith(other: string, position?: i32): bool;
   indexOf(other: string, fromIndex?: i32): i32;
   lastIndexOf(other: string, fromIndex?: i32): i32;
   localeCompare(other: string): i32;
   includes(other: string): bool;
-  startsWith(other: string): bool;
+  startsWith(other: string, position?: i32): bool;
   substr(start: i32, length?: i32): string;
   substring(start: i32, end?: i32): string;
   trim(): string;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith#position
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith#endposition
