### PR TITLE
feat(as): add scanner to identify closure functions and variables 

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -22,6 +22,7 @@
 *.inc
 
 /third_party/
+/debugger/out/
 
 /tests/bootstrap/tmp/*
 

--- a/assemblyscript/src/ast/closureScanner.ts
+++ b/assemblyscript/src/ast/closureScanner.ts
@@ -118,7 +118,6 @@ class FunctionScope {
       return false;
     } else {
       variableDeclaration.markCaptured();
-      this.markAsClosureFunction();
       return true;
     }
   }
@@ -192,10 +191,17 @@ class FunctionScopeChain {
     for (let i = this.functionScopes_.length - 2; i >= 0; i--) {
       const functionScope = this.functionScopes_[i];
       if (functionScope.markVariableCapturedIfExists(name)) {
+        this.markRangeAsClosureFunction(i);
         return true;
       }
     }
     return false;
+  }
+
+  private markRangeAsClosureFunction(start: i32): void {
+    for (let i = start; i < this.functionScopes_.length; i++) {
+      this.functionScopes_[i].markAsClosureFunction();
+    }
   }
 
   markCurrentFunctionAsClosure(): void {
@@ -292,10 +298,6 @@ export class ClosureScanner extends BaseVisitor {
   }
 
   visitIdentifierExpression(node: IdentifierExpression): void {
-    const isClosureVariable = this.functionScopeChain_.checkAndMarkClosureVariable(node.text);
-    if (isClosureVariable) {
-      // If the a function used a closure variable
-      this.functionScopeChain_.markCurrentFunctionAsClosure();
-    }
+    this.functionScopeChain_.checkAndMarkClosureVariable(node.text);
   }
 }

--- a/assemblyscript/src/compiler.ts
+++ b/assemblyscript/src/compiler.ts
@@ -897,8 +897,8 @@ export class Compiler extends DiagnosticEmitter {
     if (file.is(CommonFlags.Compiled)) return;
     file.set(CommonFlags.Compiled);
 
-    // let closureScanner = new ClosureScanner();
-    // file.source.accept(closureScanner);
+    let closureScanner = new ClosureScanner();
+    file.source.accept(closureScanner);
 
     // compile top-level statements within the file's start function
     let startFunction = file.startFunction;

--- a/tests/assemblyscript/ast/closureScanner.test.ts
+++ b/tests/assemblyscript/ast/closureScanner.test.ts
@@ -94,33 +94,31 @@ describe("closureScanner", () => {
     }
   });
 
-  // TODO: decide if middle should be a closure function
-  //   test("deep nesting: middle function is not a closure", () => {
-  //     const scanner = makeScanner(`
-  //       export function outer(): i32 {
-  //           let a = 1;
-  //           function middle(): i32 {
-  //               function inner(): i32 {
-  //                   return a;
-  //               }
-  //               return inner();
-  //           }
-  //           return middle();
-  //       }
-  //     `);
-  //     // middle does not capture anything and nothing is captured from middle
-  //     expect(scanner.closureFunctions.size).equal(2);
-  //     for (let keys = scanner.closureFunctions.keys(), j = 0, k = keys.length; j < k; j++) {
-  //       const func = keys[j];
-  //       const name = func.name.text;
-  //       assert(name === "outer" || name === "inner", `Unexpected closure function: ${name}`);
-  //       if (name === "outer") {
-  //         expect(scanner.closureFunctions.get(func).size).equal(1);
-  //       } else {
-  //         expect(scanner.closureFunctions.get(func).size).equal(0);
-  //       }
-  //     }
-  //   });
+  test("deep nesting: middle function is also a closure", () => {
+    const scanner = makeScanner(`
+        export function outer(): i32 {
+            let a = 1;
+            function middle(): i32 {
+                function inner(): i32 {
+                    return a;
+                }
+                return inner();
+            }
+            return middle();
+        }
+      `);
+    // outer provides 'a', middle and inner both transitively depend on it
+    expect(scanner.closureFunctions.size).equal(3);
+    for (let keys = scanner.closureFunctions.keys(), j = 0, k = keys.length; j < k; j++) {
+      const func = keys[j];
+      const name = func.name.text;
+      if (name === "outer") {
+        expect(scanner.closureFunctions.get(func).size).equal(1);
+      } else {
+        expect(scanner.closureFunctions.get(func).size).equal(0);
+      }
+    }
+  });
 
   test("closure inside if block", () => {
     const scanner = makeScanner(`


### PR DESCRIPTION
create a new vistor class, inheirit from BaseVistor,

Visist all idendifer expressions,

create a new resolver lite, this resolver lite should have addScopedLocal, push, pop.
push and pop when met any control flow blocks.

At each declaration expression, call addScopedLocal to add to current scope. 
Array<Arrary
Map<name, variableDeclarationAST>>>

Frist level is function, seceond level scope in function. each scope contains a map.


Set<FunctionAstPtr> record if each function is a closure function

Set<AstDelarationPtr> record if each varaible is a closure variable

 


