### PR TITLE
feat(as): minor optimize for GC threshold calculation

### DIFF
--- a/assemblyscript/std/assembly/rt/itcms.ts
+++ b/assemblyscript/std/assembly/rt/itcms.ts
@@ -401,7 +401,12 @@ function interrupt(): void {
     budget -= step();
     if (state == STATE_IDLE) {
       if (TRACE) trace("└ GC (auto) done at cur/max", 2, total, memory.size() << 16);
-      threshold = <usize>((<u64>total * IDLEFACTOR) / 100) + GRANULARITY;
+      if (IDLEFACTOR % 100 == 0) {
+        // optimization for the default GC parameters which idle factor is 200%
+        threshold = total * (IDLEFACTOR / 100) + GRANULARITY;
+      } else {
+        threshold = <usize>((<u64>total * IDLEFACTOR) / 100) + GRANULARITY;
+      }
       return;
     }
   } while (budget > 0);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:debug_symbol": "cross-env-shell ./build/tests/dwarf/TestDebugSymbol",
     "test:debug_symbol:update": "cross-env-shell build/tests/dwarf/TestDebugSymbol --update-fixtures",
     "test:debug_server": "node --import tsx --test tools/debug_server/tests/**/*.test.ts",
-    "test:driver": "node --test tests/driver/index.mjs",
+    "test:driver": "node tests/driver/index.mjs",
     "test": "npm run test:as:ut && npm run test:cpp:ut && npm run test:as:snapshot && npm run test:opt:snapshot && npm run test:driver && npm run test:debug_symbol",
     "test:all": "npm run test && npm run test:bootstrap:debug && npm run test:bootstrap:release",
     "test:update": "npm run test:as:snapshot -- -u && npm run test:opt:snapshot -- -u && npm run test:driver -- -u && npm run test:debug_symbol -- -u",

--- a/tests/driver/asconfig/build/asconfig.wat
+++ b/tests/driver/asconfig/build/asconfig.wat
@@ -1274,12 +1274,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/assignment-chain.opt.wat
+++ b/tests/frontend/compiler/assignment-chain.opt.wat
@@ -1161,12 +1161,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/assignment-chain.wat
+++ b/tests/frontend/compiler/assignment-chain.wat
@@ -2162,19 +2162,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/call-inferred.opt.wat
+++ b/tests/frontend/compiler/call-inferred.opt.wat
@@ -1241,12 +1241,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/call-inferred.wat
+++ b/tests/frontend/compiler/call-inferred.wat
@@ -2195,19 +2195,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/call-rest.opt.wat
+++ b/tests/frontend/compiler/call-rest.opt.wat
@@ -1340,12 +1340,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/call-rest.wat
+++ b/tests/frontend/compiler/call-rest.wat
@@ -2276,19 +2276,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/call-super.opt.wat
+++ b/tests/frontend/compiler/call-super.opt.wat
@@ -1157,12 +1157,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/call-super.wat
+++ b/tests/frontend/compiler/call-super.wat
@@ -2251,19 +2251,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/class-implements.opt.wat
+++ b/tests/frontend/compiler/class-implements.opt.wat
@@ -1292,12 +1292,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/class-implements.wat
+++ b/tests/frontend/compiler/class-implements.wat
@@ -2161,19 +2161,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/class-overloading-cast.opt.wat
+++ b/tests/frontend/compiler/class-overloading-cast.opt.wat
@@ -1195,12 +1195,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/class-overloading-cast.wat
+++ b/tests/frontend/compiler/class-overloading-cast.wat
@@ -2179,19 +2179,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/class-overloading.opt.wat
+++ b/tests/frontend/compiler/class-overloading.opt.wat
@@ -1218,12 +1218,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/class-overloading.wat
+++ b/tests/frontend/compiler/class-overloading.wat
@@ -2183,19 +2183,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/class-override.opt.wat
+++ b/tests/frontend/compiler/class-override.opt.wat
@@ -1254,12 +1254,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/class-override.wat
+++ b/tests/frontend/compiler/class-override.wat
@@ -2192,19 +2192,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/class.opt.wat
+++ b/tests/frontend/compiler/class.opt.wat
@@ -1263,12 +1263,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/class.wat
+++ b/tests/frontend/compiler/class.wat
@@ -2336,19 +2336,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/computed-property-class-static-field.opt.wat
+++ b/tests/frontend/compiler/computed-property-class-static-field.opt.wat
@@ -1274,12 +1274,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/computed-property-class-static-field.wat
+++ b/tests/frontend/compiler/computed-property-class-static-field.wat
@@ -2151,19 +2151,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/computed-property.opt.wat
+++ b/tests/frontend/compiler/computed-property.opt.wat
@@ -1281,12 +1281,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/computed-property.wat
+++ b/tests/frontend/compiler/computed-property.wat
@@ -2152,19 +2152,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/constructor.opt.wat
+++ b/tests/frontend/compiler/constructor.opt.wat
@@ -1310,12 +1310,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/constructor.wat
+++ b/tests/frontend/compiler/constructor.wat
@@ -2155,19 +2155,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/do.opt.wat
+++ b/tests/frontend/compiler/do.opt.wat
@@ -1164,12 +1164,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/do.wat
+++ b/tests/frontend/compiler/do.wat
@@ -2716,19 +2716,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/duplicate-fields.opt.wat
+++ b/tests/frontend/compiler/duplicate-fields.opt.wat
@@ -1260,12 +1260,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/duplicate-fields.wat
+++ b/tests/frontend/compiler/duplicate-fields.wat
@@ -2183,19 +2183,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/empty-exportruntime.opt.wat
+++ b/tests/frontend/compiler/empty-exportruntime.opt.wat
@@ -1261,12 +1261,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/empty-exportruntime.wat
+++ b/tests/frontend/compiler/empty-exportruntime.wat
@@ -2145,19 +2145,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/empty-new.opt.wat
+++ b/tests/frontend/compiler/empty-new.opt.wat
@@ -1206,12 +1206,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/empty-new.wat
+++ b/tests/frontend/compiler/empty-new.wat
@@ -2138,19 +2138,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/exportstar-rereexport.opt.wat
+++ b/tests/frontend/compiler/exportstar-rereexport.opt.wat
@@ -1189,12 +1189,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/exportstar-rereexport.wat
+++ b/tests/frontend/compiler/exportstar-rereexport.wat
@@ -2200,19 +2200,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/extends-baseaggregate.opt.wat
+++ b/tests/frontend/compiler/extends-baseaggregate.opt.wat
@@ -1261,12 +1261,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/extends-baseaggregate.wat
+++ b/tests/frontend/compiler/extends-baseaggregate.wat
@@ -2173,19 +2173,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/extends-recursive.opt.wat
+++ b/tests/frontend/compiler/extends-recursive.opt.wat
@@ -1208,12 +1208,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/extends-recursive.wat
+++ b/tests/frontend/compiler/extends-recursive.wat
@@ -2165,19 +2165,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/extension/utf8_const_str.opt.wat
+++ b/tests/frontend/compiler/extension/utf8_const_str.opt.wat
@@ -1247,12 +1247,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/extension/utf8_const_str.wat
+++ b/tests/frontend/compiler/extension/utf8_const_str.wat
@@ -2162,19 +2162,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/field-initialization.opt.wat
+++ b/tests/frontend/compiler/field-initialization.opt.wat
@@ -1262,12 +1262,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/field-initialization.wat
+++ b/tests/frontend/compiler/field-initialization.wat
@@ -2175,19 +2175,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/field.opt.wat
+++ b/tests/frontend/compiler/field.opt.wat
@@ -1252,12 +1252,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/field.wat
+++ b/tests/frontend/compiler/field.wat
@@ -2143,19 +2143,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/for.opt.wat
+++ b/tests/frontend/compiler/for.opt.wat
@@ -1164,12 +1164,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/for.wat
+++ b/tests/frontend/compiler/for.wat
@@ -2692,19 +2692,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/function-call.opt.wat
+++ b/tests/frontend/compiler/function-call.opt.wat
@@ -1314,12 +1314,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/function-call.wat
+++ b/tests/frontend/compiler/function-call.wat
@@ -2196,19 +2196,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/function-expression.opt.wat
+++ b/tests/frontend/compiler/function-expression.opt.wat
@@ -1446,12 +1446,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/function-expression.wat
+++ b/tests/frontend/compiler/function-expression.wat
@@ -2512,19 +2512,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/getter-call.opt.wat
+++ b/tests/frontend/compiler/getter-call.opt.wat
@@ -1164,12 +1164,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/getter-call.wat
+++ b/tests/frontend/compiler/getter-call.wat
@@ -2156,19 +2156,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/impl-interface-in-base.opt.wat
+++ b/tests/frontend/compiler/impl-interface-in-base.opt.wat
@@ -1208,12 +1208,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/impl-interface-in-base.wat
+++ b/tests/frontend/compiler/impl-interface-in-base.wat
@@ -2166,19 +2166,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/incremental-gc/call-indirect.opt.wat
+++ b/tests/frontend/compiler/incremental-gc/call-indirect.opt.wat
@@ -1168,12 +1168,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/incremental-gc/call-indirect.wat
+++ b/tests/frontend/compiler/incremental-gc/call-indirect.wat
@@ -2237,19 +2237,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/infer-array.opt.wat
+++ b/tests/frontend/compiler/infer-array.opt.wat
@@ -1281,12 +1281,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/infer-array.wat
+++ b/tests/frontend/compiler/infer-array.wat
@@ -2158,19 +2158,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/infer-generic.opt.wat
+++ b/tests/frontend/compiler/infer-generic.opt.wat
@@ -1291,12 +1291,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/infer-generic.wat
+++ b/tests/frontend/compiler/infer-generic.wat
@@ -2312,19 +2312,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/inlining.opt.wat
+++ b/tests/frontend/compiler/inlining.opt.wat
@@ -1389,12 +1389,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/inlining.wat
+++ b/tests/frontend/compiler/inlining.wat
@@ -2547,19 +2547,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/instanceof.opt.wat
+++ b/tests/frontend/compiler/instanceof.opt.wat
@@ -1262,12 +1262,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/instanceof.wat
+++ b/tests/frontend/compiler/instanceof.wat
@@ -2177,19 +2177,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/issues/1095.opt.wat
+++ b/tests/frontend/compiler/issues/1095.opt.wat
@@ -1277,12 +1277,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/issues/1095.wat
+++ b/tests/frontend/compiler/issues/1095.wat
@@ -2277,19 +2277,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/issues/1225.opt.wat
+++ b/tests/frontend/compiler/issues/1225.opt.wat
@@ -1230,12 +1230,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/issues/1225.wat
+++ b/tests/frontend/compiler/issues/1225.wat
@@ -2190,19 +2190,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/issues/1699.opt.wat
+++ b/tests/frontend/compiler/issues/1699.opt.wat
@@ -1252,12 +1252,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/issues/1699.wat
+++ b/tests/frontend/compiler/issues/1699.wat
@@ -2142,19 +2142,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/issues/2166.opt.wat
+++ b/tests/frontend/compiler/issues/2166.opt.wat
@@ -1166,12 +1166,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/issues/2166.wat
+++ b/tests/frontend/compiler/issues/2166.wat
@@ -2160,19 +2160,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/issues/2322/index.opt.wat
+++ b/tests/frontend/compiler/issues/2322/index.opt.wat
@@ -1156,12 +1156,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/issues/2322/index.wat
+++ b/tests/frontend/compiler/issues/2322/index.wat
@@ -2154,19 +2154,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/issues/2622.opt.wat
+++ b/tests/frontend/compiler/issues/2622.opt.wat
@@ -1195,12 +1195,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/issues/2622.wat
+++ b/tests/frontend/compiler/issues/2622.wat
@@ -2157,19 +2157,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/issues/2622/_a.opt.wat
+++ b/tests/frontend/compiler/issues/2622/_a.opt.wat
@@ -1219,12 +1219,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/issues/2622/_a.wat
+++ b/tests/frontend/compiler/issues/2622/_a.wat
@@ -2154,19 +2154,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/issues/2707.opt.wat
+++ b/tests/frontend/compiler/issues/2707.opt.wat
@@ -1169,12 +1169,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/issues/2707.wat
+++ b/tests/frontend/compiler/issues/2707.wat
@@ -2148,19 +2148,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/issues/2873.opt.wat
+++ b/tests/frontend/compiler/issues/2873.opt.wat
@@ -2348,12 +2348,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/issues/2873.wat
+++ b/tests/frontend/compiler/issues/2873.wat
@@ -4044,19 +4044,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/logical.opt.wat
+++ b/tests/frontend/compiler/logical.opt.wat
@@ -1171,12 +1171,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/logical.wat
+++ b/tests/frontend/compiler/logical.wat
@@ -2193,19 +2193,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/managed-cast.opt.wat
+++ b/tests/frontend/compiler/managed-cast.opt.wat
@@ -1166,12 +1166,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/managed-cast.wat
+++ b/tests/frontend/compiler/managed-cast.wat
@@ -2168,19 +2168,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/new.opt.wat
+++ b/tests/frontend/compiler/new.opt.wat
@@ -1197,12 +1197,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/new.wat
+++ b/tests/frontend/compiler/new.wat
@@ -2159,19 +2159,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/number.opt.wat
+++ b/tests/frontend/compiler/number.opt.wat
@@ -1326,12 +1326,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/number.wat
+++ b/tests/frontend/compiler/number.wat
@@ -2272,19 +2272,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/object-literal.opt.wat
+++ b/tests/frontend/compiler/object-literal.opt.wat
@@ -1531,12 +1531,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/object-literal.wat
+++ b/tests/frontend/compiler/object-literal.wat
@@ -2286,19 +2286,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/operator-overload-non-ambiguity.opt.wat
+++ b/tests/frontend/compiler/operator-overload-non-ambiguity.opt.wat
@@ -1158,12 +1158,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/operator-overload-non-ambiguity.wat
+++ b/tests/frontend/compiler/operator-overload-non-ambiguity.wat
@@ -2166,19 +2166,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/optional-typeparameters.opt.wat
+++ b/tests/frontend/compiler/optional-typeparameters.opt.wat
@@ -1183,12 +1183,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/optional-typeparameters.wat
+++ b/tests/frontend/compiler/optional-typeparameters.wat
@@ -2168,19 +2168,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/reexport.opt.wat
+++ b/tests/frontend/compiler/reexport.opt.wat
@@ -1249,12 +1249,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/reexport.wat
+++ b/tests/frontend/compiler/reexport.wat
@@ -2207,19 +2207,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/rereexport.opt.wat
+++ b/tests/frontend/compiler/rereexport.opt.wat
@@ -1189,12 +1189,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/rereexport.wat
+++ b/tests/frontend/compiler/rereexport.wat
@@ -2200,19 +2200,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/resolve-access.opt.wat
+++ b/tests/frontend/compiler/resolve-access.opt.wat
@@ -1264,12 +1264,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/resolve-access.wat
+++ b/tests/frontend/compiler/resolve-access.wat
@@ -2159,19 +2159,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/resolve-binary.opt.wat
+++ b/tests/frontend/compiler/resolve-binary.opt.wat
@@ -1628,12 +1628,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/resolve-binary.wat
+++ b/tests/frontend/compiler/resolve-binary.wat
@@ -2550,19 +2550,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/resolve-elementaccess.opt.wat
+++ b/tests/frontend/compiler/resolve-elementaccess.opt.wat
@@ -1310,12 +1310,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/resolve-elementaccess.wat
+++ b/tests/frontend/compiler/resolve-elementaccess.wat
@@ -2186,19 +2186,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/resolve-function-expression.opt.wat
+++ b/tests/frontend/compiler/resolve-function-expression.opt.wat
@@ -1426,12 +1426,8 @@
        i32.eqz
        if
         global.get $~lib/rt/itcms/total
-        i64.extend_i32_u
-        i64.const 200
-        i64.mul
-        i64.const 100
-        i64.div_u
-        i32.wrap_i64
+        i32.const 1
+        i32.shl
         i32.const 1024
         i32.add
         global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/resolve-function-expression.wat
+++ b/tests/frontend/compiler/resolve-function-expression.wat
@@ -2255,19 +2255,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/resolve-new.opt.wat
+++ b/tests/frontend/compiler/resolve-new.opt.wat
@@ -1163,12 +1163,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/resolve-new.wat
+++ b/tests/frontend/compiler/resolve-new.wat
@@ -2154,19 +2154,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/resolve-propertyaccess.opt.wat
+++ b/tests/frontend/compiler/resolve-propertyaccess.opt.wat
@@ -1278,12 +1278,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/resolve-propertyaccess.wat
+++ b/tests/frontend/compiler/resolve-propertyaccess.wat
@@ -2251,19 +2251,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/resolve-ternary.opt.wat
+++ b/tests/frontend/compiler/resolve-ternary.opt.wat
@@ -1326,12 +1326,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/resolve-ternary.wat
+++ b/tests/frontend/compiler/resolve-ternary.wat
@@ -2262,19 +2262,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/resolve-unary.opt.wat
+++ b/tests/frontend/compiler/resolve-unary.opt.wat
@@ -1303,12 +1303,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/resolve-unary.wat
+++ b/tests/frontend/compiler/resolve-unary.wat
@@ -2251,19 +2251,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/return-unreachable.opt.wat
+++ b/tests/frontend/compiler/return-unreachable.opt.wat
@@ -1250,12 +1250,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/return-unreachable.wat
+++ b/tests/frontend/compiler/return-unreachable.wat
@@ -2141,19 +2141,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/rt/finalize.opt.wat
+++ b/tests/frontend/compiler/rt/finalize.opt.wat
@@ -1236,12 +1236,8 @@
       i32.eqz
       if
        global.get $~lib/rt/itcms/total
-       i64.extend_i32_u
-       i64.const 200
-       i64.mul
-       i64.const 100
-       i64.div_u
-       i32.wrap_i64
+       i32.const 1
+       i32.shl
        i32.const 1024
        i32.add
        global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/rt/finalize.wat
+++ b/tests/frontend/compiler/rt/finalize.wat
@@ -2185,19 +2185,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/rt/issue-2719.opt.wat
+++ b/tests/frontend/compiler/rt/issue-2719.opt.wat
@@ -1163,12 +1163,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/rt/issue-2719.wat
+++ b/tests/frontend/compiler/rt/issue-2719.wat
@@ -2154,19 +2154,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/rt/runtime-incremental-export.opt.wat
+++ b/tests/frontend/compiler/rt/runtime-incremental-export.opt.wat
@@ -1261,12 +1261,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/rt/runtime-incremental-export.wat
+++ b/tests/frontend/compiler/rt/runtime-incremental-export.wat
@@ -2145,19 +2145,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/array-iterator.opt.wat
+++ b/tests/frontend/compiler/std/array-iterator.opt.wat
@@ -1262,12 +1262,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/array-iterator.wat
+++ b/tests/frontend/compiler/std/array-iterator.wat
@@ -2149,19 +2149,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/array-literal.opt.wat
+++ b/tests/frontend/compiler/std/array-literal.opt.wat
@@ -1348,12 +1348,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/array-literal.wat
+++ b/tests/frontend/compiler/std/array-literal.wat
@@ -2280,19 +2280,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/array.opt.wat
+++ b/tests/frontend/compiler/std/array.opt.wat
@@ -2110,12 +2110,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/array.wat
+++ b/tests/frontend/compiler/std/array.wat
@@ -2485,19 +2485,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/arraybuffer.opt.wat
+++ b/tests/frontend/compiler/std/arraybuffer.opt.wat
@@ -1260,12 +1260,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/arraybuffer.wat
+++ b/tests/frontend/compiler/std/arraybuffer.wat
@@ -2145,19 +2145,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/dataview.opt.wat
+++ b/tests/frontend/compiler/std/dataview.opt.wat
@@ -1267,12 +1267,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/dataview.wat
+++ b/tests/frontend/compiler/std/dataview.wat
@@ -2152,19 +2152,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/date.opt.wat
+++ b/tests/frontend/compiler/std/date.opt.wat
@@ -1679,12 +1679,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/date.wat
+++ b/tests/frontend/compiler/std/date.wat
@@ -2733,19 +2733,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/iterator.opt.wat
+++ b/tests/frontend/compiler/std/iterator.opt.wat
@@ -1262,12 +1262,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/iterator.wat
+++ b/tests/frontend/compiler/std/iterator.wat
@@ -2153,19 +2153,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/map-iterator.opt.wat
+++ b/tests/frontend/compiler/std/map-iterator.opt.wat
@@ -1256,12 +1256,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/map-iterator.wat
+++ b/tests/frontend/compiler/std/map-iterator.wat
@@ -2146,19 +2146,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/map.opt.wat
+++ b/tests/frontend/compiler/std/map.opt.wat
@@ -1279,12 +1279,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/map.wat
+++ b/tests/frontend/compiler/std/map.wat
@@ -2168,19 +2168,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/new.opt.wat
+++ b/tests/frontend/compiler/std/new.opt.wat
@@ -1213,12 +1213,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/new.wat
+++ b/tests/frontend/compiler/std/new.wat
@@ -2195,19 +2195,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/object.opt.wat
+++ b/tests/frontend/compiler/std/object.opt.wat
@@ -1282,12 +1282,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/object.wat
+++ b/tests/frontend/compiler/std/object.wat
@@ -2528,19 +2528,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/operator-overloading.opt.wat
+++ b/tests/frontend/compiler/std/operator-overloading.opt.wat
@@ -1600,12 +1600,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/operator-overloading.wat
+++ b/tests/frontend/compiler/std/operator-overloading.wat
@@ -2240,19 +2240,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/set-iterator.opt.wat
+++ b/tests/frontend/compiler/std/set-iterator.opt.wat
@@ -1256,12 +1256,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/set-iterator.wat
+++ b/tests/frontend/compiler/std/set-iterator.wat
@@ -2145,19 +2145,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/set.opt.wat
+++ b/tests/frontend/compiler/std/set.opt.wat
@@ -1271,12 +1271,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/set.wat
+++ b/tests/frontend/compiler/std/set.wat
@@ -2163,19 +2163,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/static-array.opt.wat
+++ b/tests/frontend/compiler/std/static-array.opt.wat
@@ -1364,12 +1364,8 @@
        i32.eqz
        if
         global.get $~lib/rt/itcms/total
-        i64.extend_i32_u
-        i64.const 200
-        i64.mul
-        i64.const 100
-        i64.div_u
-        i32.wrap_i64
+        i32.const 1
+        i32.shl
         i32.const 1024
         i32.add
         global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/static-array.wat
+++ b/tests/frontend/compiler/std/static-array.wat
@@ -2237,19 +2237,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/staticarray.opt.wat
+++ b/tests/frontend/compiler/std/staticarray.opt.wat
@@ -1666,12 +1666,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/staticarray.wat
+++ b/tests/frontend/compiler/std/staticarray.wat
@@ -2322,19 +2322,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/string-casemapping.opt.wat
+++ b/tests/frontend/compiler/std/string-casemapping.opt.wat
@@ -1691,12 +1691,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/string-casemapping.wat
+++ b/tests/frontend/compiler/std/string-casemapping.wat
@@ -2338,19 +2338,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/string-encoding.opt.wat
+++ b/tests/frontend/compiler/std/string-encoding.opt.wat
@@ -1286,12 +1286,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/string-encoding.wat
+++ b/tests/frontend/compiler/std/string-encoding.wat
@@ -2198,19 +2198,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/string-iterator.opt.wat
+++ b/tests/frontend/compiler/std/string-iterator.opt.wat
@@ -1324,12 +1324,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/string-iterator.wat
+++ b/tests/frontend/compiler/std/string-iterator.wat
@@ -2315,19 +2315,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/string.opt.wat
+++ b/tests/frontend/compiler/std/string.opt.wat
@@ -2327,12 +2327,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/string.wat
+++ b/tests/frontend/compiler/std/string.wat
@@ -3040,19 +3040,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/symbol.opt.wat
+++ b/tests/frontend/compiler/std/symbol.opt.wat
@@ -1333,12 +1333,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/symbol.wat
+++ b/tests/frontend/compiler/std/symbol.wat
@@ -2170,19 +2170,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/typedarray.opt.wat
+++ b/tests/frontend/compiler/std/typedarray.opt.wat
@@ -2124,12 +2124,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/typedarray.wat
+++ b/tests/frontend/compiler/std/typedarray.wat
@@ -2514,19 +2514,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/std/uri.opt.wat
+++ b/tests/frontend/compiler/std/uri.opt.wat
@@ -1365,12 +1365,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/std/uri.wat
+++ b/tests/frontend/compiler/std/uri.wat
@@ -2219,19 +2219,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/super-inline.opt.wat
+++ b/tests/frontend/compiler/super-inline.opt.wat
@@ -1169,12 +1169,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/super-inline.wat
+++ b/tests/frontend/compiler/super-inline.wat
@@ -2155,19 +2155,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/switch.opt.wat
+++ b/tests/frontend/compiler/switch.opt.wat
@@ -1507,12 +1507,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/switch.wat
+++ b/tests/frontend/compiler/switch.wat
@@ -2715,19 +2715,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/templateliteral.opt.wat
+++ b/tests/frontend/compiler/templateliteral.opt.wat
@@ -1465,12 +1465,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/templateliteral.wat
+++ b/tests/frontend/compiler/templateliteral.wat
@@ -2461,19 +2461,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/tuple-type-field.opt.wat
+++ b/tests/frontend/compiler/tuple-type-field.opt.wat
@@ -1257,12 +1257,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/tuple-type-field.wat
+++ b/tests/frontend/compiler/tuple-type-field.wat
@@ -2146,19 +2146,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/tuple-type-generic.opt.wat
+++ b/tests/frontend/compiler/tuple-type-generic.opt.wat
@@ -1254,12 +1254,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/tuple-type-generic.wat
+++ b/tests/frontend/compiler/tuple-type-generic.wat
@@ -2145,19 +2145,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/tuple-type.opt.wat
+++ b/tests/frontend/compiler/tuple-type.opt.wat
@@ -1293,12 +1293,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/tuple-type.wat
+++ b/tests/frontend/compiler/tuple-type.wat
@@ -2165,19 +2165,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/typeof.opt.wat
+++ b/tests/frontend/compiler/typeof.opt.wat
@@ -1590,12 +1590,8 @@
       i32.eqz
       if
        global.get $~lib/rt/itcms/total
-       i64.extend_i32_u
-       i64.const 200
-       i64.mul
-       i64.const 100
-       i64.div_u
-       i32.wrap_i64
+       i32.const 1
+       i32.shl
        i32.const 1024
        i32.add
        global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/typeof.wat
+++ b/tests/frontend/compiler/typeof.wat
@@ -2426,19 +2426,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)

--- a/tests/frontend/compiler/while.opt.wat
+++ b/tests/frontend/compiler/while.opt.wat
@@ -1164,12 +1164,8 @@
      i32.eqz
      if
       global.get $~lib/rt/itcms/total
-      i64.extend_i32_u
-      i64.const 200
-      i64.mul
-      i64.const 100
-      i64.div_u
-      i32.wrap_i64
+      i32.const 1
+      i32.shl
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold

--- a/tests/frontend/compiler/while.wat
+++ b/tests/frontend/compiler/while.wat
@@ -2769,19 +2769,22 @@
      (drop
       (i32.const 0)
      )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
      (global.set $~lib/rt/itcms/threshold
       (i32.add
-       (i32.wrap_i64
-        (i64.div_u
-         (i64.mul
-          (i64.extend_i32_u
-           (global.get $~lib/rt/itcms/total)
-          )
-          (i64.extend_i32_u
-           (i32.const 200)
-          )
-         )
-         (i64.const 100)
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
         )
        )
        (i32.const 1024)


### PR DESCRIPTION
When IDLEFACTOR is a multiple of 100, we can provide better instruction sequence
