### PR TITLE
fix(BinaryWriter): not emit debug name for non-debug mode

### DIFF
--- a/passes/BinaryWriter.cpp
+++ b/passes/BinaryWriter.cpp
@@ -10,7 +10,7 @@
 namespace warpo::passes {
 
 void BinaryWriter::write() {
-  if (hasDwarf_) {
+  if (emitDwarf_) {
     wasm::PassRunner runner{m_.get()};
     runner.add("propagate-debug-locs");
     runner.run();
@@ -26,7 +26,7 @@ void BinaryWriter::write() {
     }
   }
   writer_.write();
-  if (hasDwarf_) {
+  if (emitDwarf_) {
     debugSections_ = DwarfGenerator::generateDebugSections(m_.variableInfo_, writer_.getBinaryLocations());
     for (auto const &section : debugSections_) {
       wasm::CustomSection const customSection{

--- a/passes/BinaryWriter.hpp
+++ b/passes/BinaryWriter.hpp
@@ -20,15 +20,20 @@ class BinaryWriter {
   wasm::BufferWithRandomAccess buffer_;
   std::stringstream sourceMapStream_;
   wasm::WasmBinaryWriter writer_;
-  bool hasDwarf_ = false;
+  bool emitDwarf_ = false;
   llvm::StringMap<std::unique_ptr<llvm::MemoryBuffer>> debugSections_;
 
 public:
   explicit BinaryWriter(AsModule const &m)
       : options_(wasm::PassOptions::getWithoutOptimization()), m_(m), writer_{m.get(), buffer_, options_} {}
-  void enableSourceMap(std::string const &sourceMapURL) { writer_.setSourceMap(&sourceMapStream_, sourceMapURL); }
-  void enableNameSection() { writer_.setNamesSection(true); }
-  void enableDwarf() { hasDwarf_ = true; }
+  void setSourceMapEnabled(bool enabled, std::string const &sourceMapURL) {
+    if (enabled)
+      writer_.setSourceMap(&sourceMapStream_, sourceMapURL);
+    else
+      writer_.setSourceMap(nullptr, "");
+  }
+  void setNameSectionEnabled(bool enabled) { writer_.setNamesSection(enabled); }
+  void setDwarfEnabled(bool enabled) { emitDwarf_ = enabled; }
 
   void write();
 

--- a/passes/Runner.cpp
+++ b/passes/Runner.cpp
@@ -188,12 +188,9 @@ passes::Output passes::runOnModule(AsModule const &m, Config const &config) {
 
   // wasm and source map
   BinaryWriter writer{m};
-  if (common::isEmitDebugLine() && !config.sourceMapURL.empty())
-    writer.enableSourceMap(config.sourceMapURL);
-  if (common::isEmitDebugName())
-    writer.enableNameSection();
-  if (common::isEmitDebugInfo())
-    writer.enableDwarf();
+  writer.setSourceMapEnabled(common::isEmitDebugLine() && !config.sourceMapURL.empty(), config.sourceMapURL);
+  writer.setNameSectionEnabled(common::isEmitDebugName());
+  writer.setDwarfEnabled(common::isEmitDebugInfo());
   writer.write();
 
   // wat

--- a/tests/dwarf/TestDebugSymbol.cpp
+++ b/tests/dwarf/TestDebugSymbol.cpp
@@ -273,8 +273,9 @@ TEST_P(TestDebugSymbol_P, DebugInfo) {
 
   // wasm and source map
   warpo::passes::BinaryWriter writer{compileResult.m};
-  writer.enableSourceMap("");
-  writer.enableDwarf();
+  writer.setSourceMapEnabled(true, "");
+  writer.setNameSectionEnabled(false);
+  writer.setDwarfEnabled(true);
   writer.write();
 
   std::string const rawDump = writer.dumpDwarf();


### PR DESCRIPTION
in PR #351, we introduced binary writer to emit wasm binary. By mistake, it will emit name custom section.
In wasm-compiler, the name custom section will also emit to final JIT code binary. It significantly increases the JIT code size. It leads to performance regression in 260209.
