### PR TITLE
chore(closure): silence unused warnings in Closure pass

### DIFF
--- a/passes/Closure.cpp
+++ b/passes/Closure.cpp
@@ -72,6 +72,8 @@ public:
           wasm::EffectAnalyzer::SideEffects::WritesLocal | wasm::EffectAnalyzer::SideEffects::Calls |
           wasm::EffectAnalyzer::SideEffects::Branches | wasm::EffectAnalyzer::SideEffects::WritesMemory |
           wasm::EffectAnalyzer::SideEffects::WritesGlobal;
+      static_cast<void>(load);
+      static_cast<void>(kForbiddenEffects);
       assert(!(wasm::EffectAnalyzer(getPassOptions(), *getModule(), load->ptr).getSideEffects() & kForbiddenEffects) &&
              "address of i32.load must not write locals/globals/memory, call, or branch");
       wasm::Builder b{*getModule()};


### PR DESCRIPTION
## Bug

Fixes compiler warnings caused by variables used only inside an `assert` expression in the Closure pass.

## Fix Approach

Resolved by explicitly marking those values as used before the assertion so release/NDEBUG builds do not trigger unused-variable warnings while preserving the debug-time assertion behavior.
