### PR TITLE
chore(passes): align pass names and debug log prefixes

### DIFF
--- a/passes/AdvancedInlining.cpp
+++ b/passes/AdvancedInlining.cpp
@@ -40,7 +40,7 @@
 #include "warpo/support/Opt.hpp"
 #include "wasm.h"
 
-#define PASS_NAME "AdvInline"
+#define PASS_NAME "AdvancedInlining"
 
 using namespace wasm;
 

--- a/passes/ConditionalReturn.cpp
+++ b/passes/ConditionalReturn.cpp
@@ -53,7 +53,7 @@
 #include "wasm-type.h"
 #include "wasm.h"
 
-#define PASS_NAME "CONDITION_RETURN"
+#define PASS_NAME "ConditionalReturn"
 
 namespace warpo::passes {
 namespace {
@@ -69,7 +69,7 @@ struct Scanner : public wasm::PostWalker<Scanner> {
   }
 };
 
-wasm::Name getBlockName(size_t id) { return fmt::format(PASS_NAME "#{}", id); }
+wasm::Name getBlockName(size_t id) { return fmt::format("CONDITION_RETURN#{}", id); }
 
 wasm::Name getValidBlockName(wasm::Function *func) {
   struct Visitor final : public wasm::PostWalker<Visitor> {

--- a/passes/ExtractMostFrequentlyUsedGlobals.cpp
+++ b/passes/ExtractMostFrequentlyUsedGlobals.cpp
@@ -23,7 +23,6 @@
 #include "wasm.h"
 
 #define PASS_NAME "ExtractMostFrequentlyUsedGlobals"
-#define DEBUG_PREFIX "[ExtractMostFrequentlyUsedGlobals] "
 
 namespace warpo::passes {
 
@@ -77,7 +76,7 @@ static wasm::Name findMostFrequentlyUsed(Counter const &counter) {
   wasm::Index maxCount = 0;
   for (auto const &[name, count] : counter) {
     if (support::isDebug(PASS_NAME))
-      fmt::println(DEBUG_PREFIX "'{}' used {} times", name.str, count.load());
+      fmt::println("[" PASS_NAME "] '{}' used {} times", name.str, count.load());
     if (count.load() >= maxCount) {
       maxCount = count.load();
       maxGlobalName = name;
@@ -93,7 +92,7 @@ static void extractGlobal(wasm::Module &m, wasm::Name const name) {
   assert(eraseIt != m.globals.end());
   if (eraseIt != m.globals.begin()) {
     if (support::isDebug(PASS_NAME))
-      fmt::println(DEBUG_PREFIX "move frequently used global '{}' to index 0", name.str);
+      fmt::println("[" PASS_NAME "] move frequently used global '{}' to index 0", name.str);
     std::unique_ptr<wasm::Global> mostFrequentlyUsedGlobal = std::move(*eraseIt);
     m.globals.erase(eraseIt);
     // we don't need to consider imported global, binaryen will ignore imported global during emitting.
@@ -103,7 +102,7 @@ static void extractGlobal(wasm::Module &m, wasm::Name const name) {
     m.updateMaps();
   } else {
     if (support::isDebug(PASS_NAME)) {
-      fmt::println(DEBUG_PREFIX " most frequently used global '{}' is already at index 0", name.str);
+      fmt::println("[" PASS_NAME "] most frequently used global '{}' is already at index 0", name.str);
     }
   }
 }

--- a/passes/GC/CollectLeafFunction.cpp
+++ b/passes/GC/CollectLeafFunction.cpp
@@ -11,8 +11,7 @@
 #include "warpo/support/Debug.hpp"
 #include "wasm.h"
 
-#define PASS_NAME "GCLeafFunction"
-#define DEBUG_PREFIX "[GCLeafFunction] "
+#define PASS_NAME "GCCollectLeafFunction"
 
 namespace warpo::passes::gc {
 
@@ -46,7 +45,7 @@ void LeafFunctionCollector::run(wasm::Module *m) {
   if (support::isDebug(PASS_NAME)) {
     for (wasm::Name const &name : *result_) {
       if (support::isDebug(PASS_NAME, name.str))
-        fmt::println(DEBUG_PREFIX "leaf function: '{}'", name.str);
+        fmt::println("[" PASS_NAME "] leaf function: '{}'", name.str);
     }
   }
 }

--- a/passes/GC/ImmutableGlobalToStackRemover.cpp
+++ b/passes/GC/ImmutableGlobalToStackRemover.cpp
@@ -11,7 +11,7 @@
 #include "wasm-traversal.h"
 #include "wasm.h"
 
-#define PASS_NAME "ImmutableGlobalToStackRemover"
+#define PASS_NAME "GCImmutableGlobalToStackRemover"
 
 namespace warpo::passes::gc {
 

--- a/passes/GC/LeafFunctionFilter.cpp
+++ b/passes/GC/LeafFunctionFilter.cpp
@@ -12,7 +12,7 @@
 #include "wasm-traversal.h"
 #include "wasm.h"
 
-#define PASS_NAME "LeafFunctionFilter"
+#define PASS_NAME "GCLeafFunctionFilter"
 
 namespace warpo::passes::gc {
 

--- a/passes/GC/ObjLivenessAnalyzer.cpp
+++ b/passes/GC/ObjLivenessAnalyzer.cpp
@@ -32,8 +32,7 @@
 #include "wasm-type.h"
 #include "wasm.h"
 
-#define PASS_NAME "ObjLivenessAnalyzer"
-#define DEBUG_PREFIX "[ObjLivenessAnalyzer] "
+#define PASS_NAME "GCObjLivenessAnalyzer"
 
 namespace warpo::passes::gc {
 namespace {

--- a/passes/GC/PrologEpilogInserter.cpp
+++ b/passes/GC/PrologEpilogInserter.cpp
@@ -25,7 +25,7 @@
 #include "wasm-type.h"
 #include "wasm.h"
 
-#define PASS_NAME "PrologEpilogInserter"
+#define PASS_NAME "GCPrologEpilogInserter"
 
 namespace warpo::passes::gc {
 

--- a/passes/GC/ShrinkWrap.cpp
+++ b/passes/GC/ShrinkWrap.cpp
@@ -17,7 +17,7 @@
 #include "warpo/support/DynBitSet.hpp"
 #include "wasm.h"
 
-#define PASS_NAME "SHRINK_WRAP"
+#define PASS_NAME "GCShrinkWrap"
 
 namespace warpo::passes::gc {
 

--- a/passes/GC/StackAssigner.cpp
+++ b/passes/GC/StackAssigner.cpp
@@ -20,7 +20,7 @@
 #include "wasm-traversal.h"
 #include "wasm.h"
 
-#define PASS_NAME "STACK_ASSIGNER"
+#define PASS_NAME "GCStackAssigner"
 
 namespace warpo::passes::gc {
 

--- a/passes/GC/ToStackReplacer.cpp
+++ b/passes/GC/ToStackReplacer.cpp
@@ -20,7 +20,7 @@
 #include "wasm-type.h"
 #include "wasm.h"
 
-#define PASS_NAME "ToStackReplacer"
+#define PASS_NAME "GCToStackReplacer"
 
 namespace warpo::passes::gc {
 

--- a/passes/InsertTracePoint.cpp
+++ b/passes/InsertTracePoint.cpp
@@ -23,8 +23,7 @@
 #include "wasm-type.h"
 #include "wasm.h"
 
-#define PASS_NAME "Tracing"
-#define DEBUG_PREFIX "[Tracing] "
+#define PASS_NAME "InsertTracePoint"
 
 constexpr const char *tracePointFunctionName = "~/lib/trace_point";
 constexpr size_t traceOffset = 0x1'000000;
@@ -92,7 +91,8 @@ struct TracingInserter : public wasm::Pass {
               b, b.makeCall(tracePointFunctionName, {b.makeConst(wasm::Literal(-index))}, wasm::Type::none),
               getCurrentPointer());
         } else {
-          fmt::println(PASS_NAME "failed to insert trace point for call import to function '{}'", targetFunc->name.str);
+          fmt::println("[" PASS_NAME "] failed to insert trace point for call import to function '{}'",
+                       targetFunc->name.str);
         }
       }
     };

--- a/passes/helper/BuildCallGraph.cpp
+++ b/passes/helper/BuildCallGraph.cpp
@@ -8,8 +8,6 @@
 #include "support/name.h"
 #include "wasm.h"
 
-#define DEBUG_PREFIX "[CallGraph] "
-
 namespace warpo::passes {
 
 CallGraph CallGraphBuilder::createResults(wasm::Module &m) {

--- a/passes/helper/ExprInserter.cpp
+++ b/passes/helper/ExprInserter.cpp
@@ -15,7 +15,7 @@
 #include "wasm-type.h"
 #include "wasm.h"
 
-#define PASS_NAME "EXPR_INSERTER"
+#define PASS_NAME "ExprInserter"
 
 namespace warpo::passes {
 


### PR DESCRIPTION
## What

This change standardizes pass debug naming across pass implementations.

## How

It aligns `PASS_NAME` with pass file naming conventions and folder scope for GC passes, and removes `DEBUG_PREFIX` macros in favor of a unified `[` `PASS_NAME` `]` debug output style.
