### PR TITLE
fix(as): add global ~lib/rt/closure/env to gc tracking

### DIFF
--- a/assemblyscript/src/builtins.ts
+++ b/assemblyscript/src/builtins.ts
@@ -666,7 +666,7 @@ export namespace BuiltinNames {
   // std/object.ts
   export const Object = "~lib/object/Object";
 
-  export const getClosureEnv = "~lib/rt/closure/getClosureEnv";
+  export const closureEnv = "~lib/rt/closure/env";
   export const setClosureEnv = "~lib/rt/closure/setClosureEnv";
   export const getClosureEnvByLevel = "~lib/rt/closure/getClosureEnvByLevel";
 }
@@ -9641,6 +9641,27 @@ export function compileVisitGlobals(compiler: Compiler): void {
         );
       }
     }
+  }
+
+  // compiler generated global is not within elementsByName, it need to be handled individually
+  if (module.getGlobal(BuiltinNames.closureEnv)) {
+    exprs.push(
+      module.if(
+        module.local_tee(
+          1,
+          module.global_get(BuiltinNames.closureEnv, sizeTypeRef),
+          false // internal
+        ),
+        module.call(
+          visitInstance.internalName,
+          [
+            module.local_get(1, sizeTypeRef), // tempRef != null
+            module.local_get(0, TypeRef.I32), // cookie
+          ],
+          TypeRef.None
+        )
+      )
+    );
   }
   module.addFunction(
     BuiltinNames.visit_globals,

--- a/assemblyscript/src/compiler.ts
+++ b/assemblyscript/src/compiler.ts
@@ -477,7 +477,6 @@ export class Compiler extends DiagnosticEmitter {
   /** Elements, that are module exports, already processed */
   doneModuleExports: Set<Element> = new Set();
 
-  private getClosureEnvImported: boolean = false;
   private setClosureEnvImported: boolean = false;
   private getClosureEnvByLevelImported: boolean = false;
 
@@ -720,17 +719,11 @@ export class Compiler extends DiagnosticEmitter {
   }
 
   getClosureEnv(): ExpressionRef {
-    if (!this.getClosureEnvImported) {
-      this.getClosureEnvImported = true;
-      this.module.addFunctionImport(
-        BuiltinNames.getClosureEnv,
-        BuiltinNames.externalFuncName,
-        BuiltinNames.getClosureEnv,
-        TypeRef.None,
-        TypeRef.I32
-      );
+    const type = this.program.smallTupleInstance.type.asNullable();
+    if (!this.module.getGlobal(BuiltinNames.closureEnv)) {
+      this.module.addGlobal(BuiltinNames.closureEnv, type.toRef(), true, this.makeZero(type));
     }
-    return this.module.get_closure_env();
+    return this.module.global_get(BuiltinNames.closureEnv, type.toRef());
   }
 
   setClosureEnv(value: ExpressionRef): ExpressionRef {

--- a/assemblyscript/src/compiler.ts
+++ b/assemblyscript/src/compiler.ts
@@ -7823,7 +7823,7 @@ export class Compiler extends DiagnosticEmitter {
   /** Creates an indirect call to a first-class function. */
   makeCallIndirect(
     signature: Signature,
-    functionArg: ExpressionRef,
+    functionArg: ExpressionRef, // address expr of the function
     reportNode: Node,
     operands: ExpressionRef[] | null = null,
     immediatelyDropped: bool = false
@@ -7870,12 +7870,25 @@ export class Compiler extends DiagnosticEmitter {
       }
     }
     let functionAddrExprForIndex: ExpressionRef;
+    // if the function address expr has side effects, it must be evaluated before parameters.
+    // such as if a memory load l1 is in functionArg sub tree, and other memory load l2 is in parameter sub tree
+    // then the l1 must be evaluated before l2
+    // The key challenge is here can't follow wasm nature order
+    // param
+    // functionArg
+    // call_indirect
+    // If the nature order is followed, then the functionArg will be evaluated after parameters, which can cause side effect order issue
+    // To solve this, we need to evaluate functionArg before parameters, and store the function address in a temp local if it is not trivial
+    // But if all parameters and functionArg are trivial, then we can just evaluate functionArg in place in call_indirect,
+    // which can save one local and one local.set
     if (allTrivial) {
       functionAddrExprForIndex = functionArg;
     } else {
       const tempFunctionAddrLocal = this.currentFlow.getTempLocal(Type.i32);
       const setExpr = module.local_set(tempFunctionAddrLocal.index, functionArg, false);
+      // setExpr is emitted before parameters, so it can guarantee the side effect order of functionArg and parameters, but it will cause extra local.set and local.get if functionArg is trivial, which is common in wasm, so we only emit setExpr when functionArg or parameters are not trivial
       stmts.push(setExpr);
+      // blow instructions are emitted after parameters
       functionAddrExprForEnv = module.local_get(tempFunctionAddrLocal.index, TypeRef.I32);
       functionAddrExprForIndex = module.local_get(tempFunctionAddrLocal.index, TypeRef.I32);
     }

--- a/assemblyscript/src/module.ts
+++ b/assemblyscript/src/module.ts
@@ -459,10 +459,6 @@ export class Module {
     return value;
   }
 
-  get_closure_env(): ExpressionRef {
-    return this.call(BuiltinNames.getClosureEnv, null, TypeRef.I32);
-  }
-
   set_closure_env(value: ExpressionRef): ExpressionRef {
     let type = binaryen._BinaryenExpressionGetType(value);
     assert(type == TypeRef.I32 || type == TypeRef.Unreachable);

--- a/passes/Closure.cpp
+++ b/passes/Closure.cpp
@@ -27,7 +27,6 @@
 
 namespace warpo::passes::closure {
 
-static constexpr const char *const kGetClosureEnv = "~lib/rt/closure/getClosureEnv";
 static constexpr const char *const kSetClosureEnv = "~lib/rt/closure/setClosureEnv";
 static constexpr const char *const kGetClosureEnvByLevel = "~lib/rt/closure/getClosureEnvByLevel";
 
@@ -35,8 +34,7 @@ static constexpr const char *const kSetFFIClosureEnv = "~lib/warpo/ffi/ffi.set_f
 
 static constexpr const char *const kClosureEnvGlobal = "~lib/rt/closure/env";
 
-static std::array<const char *const, 3> kClosureImportBases = {
-    kGetClosureEnv,
+static std::array<const char *const, 2> kClosureImportBases = {
     kSetClosureEnv,
     kGetClosureEnvByLevel,
 };
@@ -64,40 +62,33 @@ struct ClosureCallSummary final {
 
 class ClosureCallScanner : public wasm::WalkerPass<wasm::PostWalker<ClosureCallScanner>> {
 public:
-  ClosureCallScanner(std::atomic<bool> &hasGet, std::atomic<bool> &hasSet, std::atomic<bool> &hasFFISet)
-      : hasGet(hasGet), hasSet(hasSet), hasFFISet(hasFFISet) {}
+  ClosureCallScanner(std::atomic<bool> &hasSet, std::atomic<bool> &hasFFISet) : hasSet(hasSet), hasFFISet(hasFFISet) {}
 
   bool isFunctionParallel() override { return true; }
-  std::unique_ptr<wasm::Pass> create() override {
-    return std::make_unique<ClosureCallScanner>(hasGet, hasSet, hasFFISet);
-  }
+  std::unique_ptr<wasm::Pass> create() override { return std::make_unique<ClosureCallScanner>(hasSet, hasFFISet); }
 
   void visitCall(wasm::Call *curr) {
-    if ((curr->target == kGetClosureEnv) || (curr->target == kGetClosureEnvByLevel))
-      hasGet.store(true, std::memory_order_relaxed);
-    else if (curr->target == kSetClosureEnv)
+    if (curr->target == kSetClosureEnv)
       hasSet.store(true, std::memory_order_relaxed);
     else if (curr->target == kSetFFIClosureEnv)
       hasFFISet.store(true, std::memory_order_relaxed);
   }
 
 private:
-  std::atomic<bool> &hasGet;
   std::atomic<bool> &hasSet;
   std::atomic<bool> &hasFFISet;
 };
 
-ClosureCallSummary scanClosureCalls(wasm::PassRunner *const parentRunner) {
-  std::atomic<bool> hasGet{false};
+ClosureCallSummary scanClosureCalls(wasm::Module *const m, wasm::PassRunner *const parentRunner) {
   std::atomic<bool> hasSet{false};
   std::atomic<bool> hasFFISet{false};
   {
     wasm::PassRunner runner{parentRunner};
-    runner.add(std::make_unique<ClosureCallScanner>(hasGet, hasSet, hasFFISet));
+    runner.add(std::make_unique<ClosureCallScanner>(hasSet, hasFFISet));
     runner.run();
   }
   return {
-      hasGet.load(std::memory_order_relaxed),
+      m->getGlobalOrNull(kClosureEnvGlobal) != nullptr,
       hasSet.load(std::memory_order_relaxed),
       hasFFISet.load(std::memory_order_relaxed),
   };
@@ -108,13 +99,6 @@ void removeClosureImports(wasm::Module *const m) {
     m->removeFunction(name);
   if (m->getFunctionOrNull(kSetFFIClosureEnv) != nullptr)
     m->removeFunction(kSetFFIClosureEnv);
-}
-
-void ensureClosureEnvGlobal(wasm::Module *const m) {
-  if (m->getGlobalOrNull(kClosureEnvGlobal) != nullptr)
-    return;
-  wasm::Builder b{*m};
-  m->addGlobal(wasm::Builder::makeGlobal(kClosureEnvGlobal, wasm::Type::i32, b.makeConst(0), wasm::Builder::Mutable));
 }
 
 class SetClosureEnvRemover : public wasm::WalkerPass<wasm::PostWalker<SetClosureEnvRemover>> {
@@ -177,9 +161,7 @@ public:
 
   void visitCall(wasm::Call *const curr) {
     wasm::Builder b{*getModule()};
-    if (curr->target == kGetClosureEnv) {
-      replaceCurrent(b.makeGlobalGet(kClosureEnvGlobal, wasm::Type::i32));
-    } else if (curr->target == kSetClosureEnv) {
+    if (curr->target == kSetClosureEnv) {
       replaceCurrent(b.makeGlobalSet(kClosureEnvGlobal, curr->operands[0]));
     } else if (curr->target == kSetFFIClosureEnv) {
       replaceCurrent(lowerSetFFIClosureEnv(curr, getModule(), getFunction(), variableInfo_));
@@ -550,10 +532,9 @@ private:
 
 void FastLower::run(wasm::Module *m) {
   wasm::PassRunner *const parentRunner = getPassRunner();
-  ClosureCallSummary const summary = scanClosureCalls(parentRunner);
+  ClosureCallSummary const summary = scanClosureCalls(m, parentRunner);
 
   if (summary.needsLowering()) {
-    ensureClosureEnvGlobal(m);
     wasm::PassRunner passRunner{parentRunner};
     passRunner.add(std::make_unique<ClosureEnvCommonLower>(variableInfo_));
     passRunner.add(std::make_unique<FastGetClosureEnvByLevelLower>(variableInfo_));
@@ -567,10 +548,9 @@ void FastLower::run(wasm::Module *m) {
 
 void OptLower::run(wasm::Module *m) {
   wasm::PassRunner *const parentRunner = getPassRunner();
-  ClosureCallSummary const summary = scanClosureCalls(parentRunner);
+  ClosureCallSummary const summary = scanClosureCalls(m, parentRunner);
 
   if (summary.needsLowering()) {
-    ensureClosureEnvGlobal(m);
     {
       wasm::PassRunner passRunner{parentRunner};
       passRunner.add(std::make_unique<ClosureEnvCommonLower>(variableInfo_));
@@ -613,7 +593,6 @@ namespace {
 TEST(ClosureLower, SetOnlyRemovesCallsAndFunctions) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
       (memory 1)
@@ -627,7 +606,6 @@ TEST(ClosureLower, SetOnlyRemovesCallsAndFunctions) {
   runner.add(std::unique_ptr<wasm::Pass>{new closure::FastLower(nullptr)});
   runner.run();
 
-  EXPECT_EQ(m->getFunctionOrNull("~lib/rt/closure/getClosureEnv"), nullptr);
   EXPECT_EQ(m->getFunctionOrNull("~lib/rt/closure/setClosureEnv"), nullptr);
   EXPECT_EQ(m->getFunctionOrNull("~lib/rt/closure/getClosureEnvByLevel"), nullptr);
 
@@ -639,7 +617,6 @@ TEST(ClosureLower, SetOnlyRemovesCallsAndFunctions) {
 TEST(ClosureLower, NoClosureCallsKeepsFunctions) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
       (func $caller
@@ -652,7 +629,6 @@ TEST(ClosureLower, NoClosureCallsKeepsFunctions) {
   runner.add(std::unique_ptr<wasm::Pass>{new closure::FastLower(nullptr)});
   runner.run();
 
-  EXPECT_EQ(m->getFunctionOrNull("~lib/rt/closure/getClosureEnv"), nullptr);
   EXPECT_EQ(m->getFunctionOrNull("~lib/rt/closure/setClosureEnv"), nullptr);
   EXPECT_EQ(m->getFunctionOrNull("~lib/rt/closure/getClosureEnvByLevel"), nullptr);
 }
@@ -660,15 +636,15 @@ TEST(ClosureLower, NoClosureCallsKeepsFunctions) {
 TEST(ClosureLower, BothGetAndSetLowersToGlobalAndLocal) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $setter
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
       )
       (func $getter (result i32)
-        (call $~lib/rt/closure/getClosureEnv)
+        (global.get $~lib/rt/closure/env)
       )
       (func $levelGetter (result i32) (local i32)
         (call $~lib/rt/closure/getClosureEnvByLevel (i32.const 0))
@@ -684,7 +660,6 @@ TEST(ClosureLower, BothGetAndSetLowersToGlobalAndLocal) {
   runner.add(std::unique_ptr<wasm::Pass>{new closure::FastLower(&variableInfo)});
   runner.run();
 
-  EXPECT_EQ(m->getFunctionOrNull("~lib/rt/closure/getClosureEnv"), nullptr);
   EXPECT_EQ(m->getFunctionOrNull("~lib/rt/closure/setClosureEnv"), nullptr);
   EXPECT_EQ(m->getFunctionOrNull("~lib/rt/closure/getClosureEnvByLevel"), nullptr);
 
@@ -706,9 +681,9 @@ TEST(ClosureLower, BothGetAndSetLowersToGlobalAndLocal) {
 TEST(ClosureLower, GetClosureEnvByLevelWithChainedLoads) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $setter
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -750,7 +725,6 @@ TEST(ClosureLower, GetClosureEnvByLevelWithChainedLoads) {
 TEST(ClosureLower, FFISetClosureEnvLowersToStore) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
       (import "as-builtin-fn" "set_ffi_closure_env" (func $~lib/warpo/ffi/ffi.set_ffi_closure_env (param i32)))
@@ -785,9 +759,9 @@ TEST(ClosureLower, FFISetClosureEnvLowersToStore) {
 TEST(ClosureLower, OptLowerCachesFromClosestDef) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -833,9 +807,9 @@ TEST(ClosureLower, OptLowerCachesFromClosestDef) {
 TEST(ClosureLower, OptLowerNoCachingWhenSingleUse) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -868,9 +842,9 @@ TEST(ClosureLower, OptLowerNoCachingWhenSingleUse) {
 TEST(ClosureLower, OptLowerSingleLevelRepeated) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -921,9 +895,9 @@ TEST(ClosureLower, OptLowerSingleLevelRepeated) {
 TEST(ClosureLower, OptLowerReusesDominatingDefAcrossBasicBlocks) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (param i32) (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -983,9 +957,9 @@ TEST(ClosureLower, OptLowerReusesDominatingDefAcrossBasicBlocks) {
 TEST(ClosureLower, OptLowerReusesExactDominatingDefAcrossBasicBlocks) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (param i32) (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -1045,9 +1019,9 @@ TEST(ClosureLower, OptLowerReusesExactDominatingDefAcrossBasicBlocks) {
 TEST(ClosureLower, OptLowerCreatesChildDefFromDominatingParentCache) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (param i32) (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -1122,9 +1096,9 @@ TEST(ClosureLower, OptLowerCreatesChildDefFromDominatingParentCache) {
 TEST(ClosureLower, OptLowerHoistsDefToTopMostReusableDominator) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (param i32) (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -1208,9 +1182,9 @@ TEST(ClosureLower, OptLowerHoistsDefToTopMostReusableDominator) {
 TEST(ClosureLower, OptLowerStopsHoistingAtNonReusableAncestor) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (param i32 i32) (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -1310,9 +1284,9 @@ TEST(ClosureLower, OptLowerStopsHoistingAtNonReusableAncestor) {
 TEST(ClosureLower, OptLowerThreeLevelsChaining) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -1383,9 +1357,9 @@ TEST(ClosureLower, OptLowerThreeLevelsChaining) {
 TEST(ClosureLower, OptLowerLevelZeroNoCaching) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -1421,9 +1395,9 @@ TEST(ClosureLower, OptLowerLevelZeroNoCaching) {
 TEST(ClosureLower, OptLowerCachesIndependentlyInIfElseBranches) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (param i32) (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -1523,9 +1497,9 @@ TEST(ClosureLower, OptLowerCachesIndependentlyInIfElseBranches) {
 TEST(ClosureLower, OptLowerCachesSingleMaxLevelWhenCountExceedsOne) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -1583,9 +1557,9 @@ TEST(ClosureLower, OptLowerCachesSingleMaxLevelWhenCountExceedsOne) {
 TEST(ClosureLower, OptLowerHoistsPastIntermediateDomWithoutClosureCalls) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (param i32 i32) (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -1681,9 +1655,9 @@ TEST(ClosureLower, OptLowerHoistsPastIntermediateDomWithoutClosureCalls) {
 TEST(ClosureLower, OptLowerHoistsOutOfLoop) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (param i32) (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -1739,9 +1713,9 @@ TEST(ClosureLower, OptLowerHoistsOutOfLoop) {
 TEST(ClosureLower, OptLowerHoistsOutOfNestedLoop) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (param i32 i32) (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -1802,9 +1776,9 @@ TEST(ClosureLower, OptLowerHoistsOutOfNestedLoop) {
 TEST(ClosureLower, OptLowerSkipsHoistWhenLoopBlockExits) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (param i32) (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))
@@ -1851,9 +1825,9 @@ TEST(ClosureLower, OptLowerSkipsHoistWhenLoopBlockExits) {
 TEST(ClosureLower, OptLowerHoistsLoopDefToBlockWithClosureCall) {
   auto m = loadWat(R"(
     (module
-      (import "env" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
       (import "env" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
       (import "env" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+      (global $~lib/rt/closure/env (mut i32) (i32.const 0))
       (memory 1)
       (func $levelGetter (param i32) (result i32) (local i32)
         (call $~lib/rt/closure/setClosureEnv (i32.const 42))

--- a/tests/frontend/compiler/closure-arrow-in-function.opt.wat
+++ b/tests/frontend/compiler/closure-arrow-in-function.opt.wat
@@ -40,6 +40,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-arrow-in-function.wat
+++ b/tests/frontend/compiler/closure-arrow-in-function.wat
@@ -4,15 +4,14 @@
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
  (type $4 (func (param i32 i32) (result i32)))
- (type $5 (func (result i32)))
- (type $6 (func))
+ (type $5 (func))
+ (type $6 (func (result i32)))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
  (type $9 (func (param i32 i32 i64) (result i32)))
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 496))
  (global $~lib/memory/__data_end i32 (i32.const 524))
@@ -3111,7 +3111,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3185,7 +3185,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3205,7 +3205,7 @@
    )
   )
   (return
-   (call_indirect (type $5)
+   (call_indirect (type $6)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3275,7 +3275,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-basic.opt.wat
+++ b/tests/frontend/compiler/closure-basic.opt.wat
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-basic.wat
+++ b/tests/frontend/compiler/closure-basic.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 480))
  (global $~lib/memory/__data_end i32 (i32.const 508))
@@ -3111,7 +3111,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3169,7 +3169,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3263,7 +3263,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-block-scope.opt.wat
+++ b/tests/frontend/compiler/closure-capture-block-scope.opt.wat
@@ -39,6 +39,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-block-scope.wat
+++ b/tests/frontend/compiler/closure-capture-block-scope.wat
@@ -4,15 +4,14 @@
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
  (type $4 (func (param i32 i32) (result i32)))
- (type $5 (func (result i32)))
- (type $6 (func))
+ (type $5 (func))
+ (type $6 (func (result i32)))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
  (type $9 (func (param i32 i32 i64) (result i32)))
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 496))
  (global $~lib/memory/__data_end i32 (i32.const 524))
@@ -3111,7 +3111,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3167,7 +3167,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $x
@@ -3236,7 +3236,7 @@
         (call $closure-capture-block-scope/outer)
        )
       )
-      (call_indirect (type $5)
+      (call_indirect (type $6)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3268,7 +3268,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-do-while-body.opt.wat
+++ b/tests/frontend/compiler/closure-capture-do-while-body.opt.wat
@@ -20,8 +20,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33436))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33436))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -45,6 +45,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-do-while-body.wat
+++ b/tests/frontend/compiler/closure-capture-do-while-body.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -31,6 +30,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 640))
  (global $~lib/memory/__data_end i32 (i32.const 668))
@@ -3114,7 +3114,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3171,7 +3171,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $i
@@ -3426,7 +3426,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-do-while-upper-level.opt.wat
+++ b/tests/frontend/compiler/closure-capture-do-while-upper-level.opt.wat
@@ -20,8 +20,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33452))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33452))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -45,6 +45,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-do-while-upper-level.wat
+++ b/tests/frontend/compiler/closure-capture-do-while-upper-level.wat
@@ -3,8 +3,8 @@
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
- (type $4 (func (result i32)))
- (type $5 (func (param i32 i32) (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (result i32)))
  (type $6 (func))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -31,6 +30,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 656))
  (global $~lib/memory/__data_end i32 (i32.const 684))
@@ -3114,7 +3114,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3182,7 +3182,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3390,7 +3390,7 @@
         )
        )
       )
-      (call_indirect (type $4)
+      (call_indirect (type $5)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3444,7 +3444,7 @@
         )
        )
       )
-      (call_indirect (type $4)
+      (call_indirect (type $5)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3476,7 +3476,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-for-of-mixed.opt.wat
+++ b/tests/frontend/compiler/closure-capture-for-of-mixed.opt.wat
@@ -50,6 +50,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-for-of-mixed.wat
+++ b/tests/frontend/compiler/closure-capture-for-of-mixed.wat
@@ -13,7 +13,6 @@
  (type $11 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -33,6 +32,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 672))
  (global $~lib/memory/__data_end i32 (i32.const 720))
@@ -3380,7 +3380,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3433,7 +3433,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3478,7 +3478,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3937,7 +3937,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-loop-control-var.opt.wat
+++ b/tests/frontend/compiler/closure-capture-loop-control-var.opt.wat
@@ -20,8 +20,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33436))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33436))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -45,6 +45,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-loop-control-var.wat
+++ b/tests/frontend/compiler/closure-capture-loop-control-var.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -31,6 +30,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 640))
  (global $~lib/memory/__data_end i32 (i32.const 668))
@@ -3098,7 +3098,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3170,7 +3170,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $iii
@@ -3446,7 +3446,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-loop-double-init.opt.wat
+++ b/tests/frontend/compiler/closure-capture-loop-double-init.opt.wat
@@ -20,8 +20,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33436))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33436))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -45,6 +45,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-loop-double-init.wat
+++ b/tests/frontend/compiler/closure-capture-loop-double-init.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -31,6 +30,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 640))
  (global $~lib/memory/__data_end i32 (i32.const 668))
@@ -3098,7 +3098,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3181,7 +3181,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (block
@@ -3485,7 +3485,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-loop-mixed.opt.wat
+++ b/tests/frontend/compiler/closure-capture-loop-mixed.opt.wat
@@ -21,8 +21,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33420))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33420))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -45,6 +45,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-loop-mixed.wat
+++ b/tests/frontend/compiler/closure-capture-loop-mixed.wat
@@ -2,8 +2,8 @@
  (type $0 (func (param i32) (result i32)))
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
- (type $3 (func (result i32)))
- (type $4 (func (param i32 i32 i32)))
+ (type $3 (func (param i32 i32 i32)))
+ (type $4 (func (result i32)))
  (type $5 (func (param i32 i32) (result i32)))
  (type $6 (func))
  (type $7 (func (param i32 i32 i32 i32)))
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -32,6 +31,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 624))
  (global $~lib/memory/__data_end i32 (i32.const 652))
@@ -3115,7 +3115,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3168,7 +3168,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3205,7 +3205,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3414,7 +3414,7 @@
         )
        )
       )
-      (call_indirect (type $3)
+      (call_indirect (type $4)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3502,7 +3502,7 @@
         )
        )
       )
-      (call_indirect (type $3)
+      (call_indirect (type $4)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3556,7 +3556,7 @@
         )
        )
       )
-      (call_indirect (type $3)
+      (call_indirect (type $4)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3588,7 +3588,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-variable-in-do-while.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-do-while.opt.wat
@@ -19,8 +19,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33452))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33452))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -44,6 +44,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-variable-in-do-while.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-do-while.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -30,6 +29,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 656))
  (global $~lib/memory/__data_end i32 (i32.const 684))
@@ -3113,7 +3113,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3169,7 +3169,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (block $do-break|0
@@ -3327,7 +3327,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-variable-in-for-of-body.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-for-of-body.opt.wat
@@ -49,6 +49,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-variable-in-for-of-body.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-for-of-body.wat
@@ -4,8 +4,8 @@
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32) (result i32)))
  (type $4 (func (param i32 i32 i32)))
- (type $5 (func (result i32)))
- (type $6 (func))
+ (type $5 (func))
+ (type $6 (func (result i32)))
  (type $7 (func (param i32 i32 i32) (result i32)))
  (type $8 (func (param i32 i32 i32 i32)))
  (type $9 (func (param i32 i32 i64) (result i32)))
@@ -13,7 +13,6 @@
  (type $11 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -32,6 +31,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 688))
  (global $~lib/memory/__data_end i32 (i32.const 736))
@@ -3379,7 +3379,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3441,7 +3441,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $arr
@@ -3656,7 +3656,7 @@
         )
        )
       )
-      (call_indirect (type $5)
+      (call_indirect (type $6)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3710,7 +3710,7 @@
         )
        )
       )
-      (call_indirect (type $5)
+      (call_indirect (type $6)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3742,7 +3742,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-variable-in-for-of-upper-level.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-for-of-upper-level.opt.wat
@@ -49,6 +49,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-variable-in-for-of-upper-level.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-for-of-upper-level.wat
@@ -3,8 +3,8 @@
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32) (result i32)))
- (type $4 (func (result i32)))
- (type $5 (func (param i32 i32 i32)))
+ (type $4 (func (param i32 i32 i32)))
+ (type $5 (func (result i32)))
  (type $6 (func))
  (type $7 (func (param i32 i32 i32) (result i32)))
  (type $8 (func (param i32 i32 i32 i32)))
@@ -13,7 +13,6 @@
  (type $11 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -32,6 +31,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 704))
  (global $~lib/memory/__data_end i32 (i32.const 752))
@@ -3379,7 +3379,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3452,7 +3452,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3706,7 +3706,7 @@
         )
        )
       )
-      (call_indirect (type $4)
+      (call_indirect (type $5)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3760,7 +3760,7 @@
         )
        )
       )
-      (call_indirect (type $4)
+      (call_indirect (type $5)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3792,7 +3792,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-variable-in-for-of.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-for-of.opt.wat
@@ -48,6 +48,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-variable-in-for-of.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-for-of.wat
@@ -4,8 +4,8 @@
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32) (result i32)))
  (type $4 (func (param i32 i32 i32)))
- (type $5 (func (result i32)))
- (type $6 (func))
+ (type $5 (func))
+ (type $6 (func (result i32)))
  (type $7 (func (param i32 i32 i32) (result i32)))
  (type $8 (func (param i32 i32 i32 i32)))
  (type $9 (func (param i32 i32 i64) (result i32)))
@@ -13,7 +13,6 @@
  (type $11 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -32,6 +31,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 672))
  (global $~lib/memory/__data_end i32 (i32.const 720))
@@ -3379,7 +3379,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3440,7 +3440,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $arr
@@ -3664,7 +3664,7 @@
         )
        )
       )
-      (call_indirect (type $5)
+      (call_indirect (type $6)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3718,7 +3718,7 @@
         )
        )
       )
-      (call_indirect (type $5)
+      (call_indirect (type $6)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3750,7 +3750,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-variable-in-loop-break-continue.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-loop-break-continue.opt.wat
@@ -21,8 +21,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33468))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33468))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -46,6 +46,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-variable-in-loop-break-continue.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-loop-break-continue.wat
@@ -3,16 +3,15 @@
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
- (type $4 (func (result i32)))
- (type $5 (func (param i32 i32) (result i32)))
- (type $6 (func))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func))
+ (type $6 (func (result i32)))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
  (type $9 (func (param i32 i32 i64) (result i32)))
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -32,6 +31,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 672))
  (global $~lib/memory/__data_end i32 (i32.const 700))
@@ -3115,7 +3115,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3171,7 +3171,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $count
@@ -3407,7 +3407,7 @@
         )
        )
       )
-      (call_indirect (type $4)
+      (call_indirect (type $6)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3461,7 +3461,7 @@
         )
        )
       )
-      (call_indirect (type $4)
+      (call_indirect (type $6)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3515,7 +3515,7 @@
         )
        )
       )
-      (call_indirect (type $4)
+      (call_indirect (type $6)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3547,7 +3547,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-variable-in-loop-upper-level.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-loop-upper-level.opt.wat
@@ -20,8 +20,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33468))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33468))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -45,6 +45,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-variable-in-loop-upper-level.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-loop-upper-level.wat
@@ -3,8 +3,8 @@
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
- (type $4 (func (result i32)))
- (type $5 (func (param i32 i32) (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (result i32)))
  (type $6 (func))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -31,6 +30,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 672))
  (global $~lib/memory/__data_end i32 (i32.const 700))
@@ -3114,7 +3114,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3182,7 +3182,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3393,7 +3393,7 @@
         )
        )
       )
-      (call_indirect (type $4)
+      (call_indirect (type $5)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3447,7 +3447,7 @@
         )
        )
       )
-      (call_indirect (type $4)
+      (call_indirect (type $5)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3479,7 +3479,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-variable-in-loop.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-loop.opt.wat
@@ -20,8 +20,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33436))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33436))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -45,6 +45,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-variable-in-loop.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-loop.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -31,6 +30,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 640))
  (global $~lib/memory/__data_end i32 (i32.const 668))
@@ -3114,7 +3114,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3171,7 +3171,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $i
@@ -3429,7 +3429,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-variable-in-while.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-while.opt.wat
@@ -20,8 +20,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33436))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33436))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -44,6 +44,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-variable-in-while.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-while.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -31,6 +30,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 640))
  (global $~lib/memory/__data_end i32 (i32.const 668))
@@ -3114,7 +3114,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3171,7 +3171,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $i
@@ -3434,7 +3434,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-capture-while-upper-level.opt.wat
+++ b/tests/frontend/compiler/closure-capture-while-upper-level.opt.wat
@@ -20,8 +20,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33436))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33436))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -44,6 +44,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-capture-while-upper-level.wat
+++ b/tests/frontend/compiler/closure-capture-while-upper-level.wat
@@ -3,8 +3,8 @@
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
- (type $4 (func (result i32)))
- (type $5 (func (param i32 i32) (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (result i32)))
  (type $6 (func))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -31,6 +30,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 640))
  (global $~lib/memory/__data_end i32 (i32.const 668))
@@ -3114,7 +3114,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3182,7 +3182,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3395,7 +3395,7 @@
         )
        )
       )
-      (call_indirect (type $4)
+      (call_indirect (type $5)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3449,7 +3449,7 @@
         )
        )
       )
-      (call_indirect (type $4)
+      (call_indirect (type $5)
        (block (result i32)
         (call $~lib/rt/closure/setClosureEnv
          (i32.load offset=4
@@ -3481,7 +3481,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-captured-from-nonclosure.opt.wat
+++ b/tests/frontend/compiler/closure-captured-from-nonclosure.opt.wat
@@ -44,6 +44,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-captured-from-nonclosure.wat
+++ b/tests/frontend/compiler/closure-captured-from-nonclosure.wat
@@ -2,8 +2,8 @@
  (type $0 (func (param i32) (result i32)))
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
- (type $3 (func (result i32)))
- (type $4 (func (param i32 i32 i32)))
+ (type $3 (func (param i32 i32 i32)))
+ (type $4 (func (result i32)))
  (type $5 (func (param i32 i32) (result i32)))
  (type $6 (func))
  (type $7 (func (param i32 i32 i32 i32)))
@@ -13,7 +13,6 @@
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
  (global $~argumentsLength (mut i32) (i32.const 0))
@@ -30,6 +29,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 544))
  (global $~lib/memory/__data_end i32 (i32.const 576))
  (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33344))
@@ -3097,7 +3097,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3112,7 +3112,7 @@
       (i32.const 4)
      )
     )
-    (call_indirect (type $3)
+    (call_indirect (type $4)
      (block (result i32)
       (call $~lib/rt/closure/setClosureEnv
        (i32.load offset=4
@@ -3191,7 +3191,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<%28%29=>i32>
@@ -3213,7 +3213,7 @@
    )
   )
   (return
-   (call_indirect (type $3)
+   (call_indirect (type $4)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3316,7 +3316,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-class-arrow-this-capture-fn.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-capture-fn.opt.wat
@@ -47,6 +47,12 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-class-arrow-this-capture-fn.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-capture-fn.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -30,6 +29,7 @@
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $closure-class-arrow-this-capture-fn/c (mut i32) (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 512))
  (global $~lib/memory/__data_end i32 (i32.const 548))
@@ -3132,7 +3132,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3243,7 +3243,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3328,7 +3328,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<closure-class-arrow-this-capture-fn/CaptureFunc>
@@ -3463,6 +3463,17 @@
   (if
    (local.tee $1
     (global.get $closure-class-arrow-this-capture-fn/c)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
    )
    (then
     (call $~lib/rt/itcms/__visit

--- a/tests/frontend/compiler/closure-class-arrow-this-constructor.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-constructor.opt.wat
@@ -18,9 +18,9 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $closure-class-arrow-this-constructor/c (mut i32) (i32.const 0))
  (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33328))
- (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -42,6 +42,12 @@
   (local $0 i32)
   (local $1 i32)
   global.get $closure-class-arrow-this-constructor/c
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $~lib/rt/closure/env
   local.tee $0
   if
    local.get $0

--- a/tests/frontend/compiler/closure-class-arrow-this-constructor.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-constructor.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $closure-class-arrow-this-constructor/c (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 528))
@@ -3106,7 +3106,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3195,7 +3195,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<closure-class-arrow-this-constructor/FromConstructor>
@@ -3324,6 +3324,17 @@
   (if
    (local.tee $1
     (global.get $closure-class-arrow-this-constructor/c)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
    )
    (then
     (call $~lib/rt/itcms/__visit

--- a/tests/frontend/compiler/closure-class-arrow-this-getter.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-getter.opt.wat
@@ -19,8 +19,8 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $closure-class-arrow-this-getter/g (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33312))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33312))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -42,6 +42,12 @@
   (local $0 i32)
   (local $1 i32)
   global.get $closure-class-arrow-this-getter/g
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $~lib/rt/closure/env
   local.tee $0
   if
    local.get $0

--- a/tests/frontend/compiler/closure-class-arrow-this-getter.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-getter.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -30,6 +29,7 @@
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $closure-class-arrow-this-getter/g (mut i32) (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 512))
  (global $~lib/memory/__data_end i32 (i32.const 544))
@@ -3121,7 +3121,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3200,7 +3200,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<closure-class-arrow-this-getter/FromGetter>
@@ -3315,6 +3315,17 @@
   (if
    (local.tee $1
     (global.get $closure-class-arrow-this-getter/g)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
    )
    (then
     (call $~lib/rt/itcms/__visit

--- a/tests/frontend/compiler/closure-class-arrow-this-method.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-method.opt.wat
@@ -19,8 +19,8 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $closure-class-arrow-this-method/m (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33312))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33312))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -42,6 +42,12 @@
   (local $0 i32)
   (local $1 i32)
   global.get $closure-class-arrow-this-method/m
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $~lib/rt/closure/env
   local.tee $0
   if
    local.get $0

--- a/tests/frontend/compiler/closure-class-arrow-this-method.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-method.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -30,6 +29,7 @@
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $closure-class-arrow-this-method/m (mut i32) (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 512))
  (global $~lib/memory/__data_end i32 (i32.const 544))
@@ -3121,7 +3121,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3200,7 +3200,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<closure-class-arrow-this-method/FromMethod>
@@ -3322,6 +3322,17 @@
   (if
    (local.tee $1
     (global.get $closure-class-arrow-this-method/m)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
    )
    (then
     (call $~lib/rt/itcms/__visit

--- a/tests/frontend/compiler/closure-class-arrow-this-nested.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-nested.opt.wat
@@ -19,8 +19,8 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $closure-class-arrow-this-nested/m (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33312))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33312))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -42,6 +42,12 @@
   (local $0 i32)
   (local $1 i32)
   global.get $closure-class-arrow-this-nested/m
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $~lib/rt/closure/env
   local.tee $0
   if
    local.get $0

--- a/tests/frontend/compiler/closure-class-arrow-this-nested.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-nested.wat
@@ -3,8 +3,8 @@
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
- (type $4 (func (result i32)))
- (type $5 (func (param i32 i32) (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (result i32)))
  (type $6 (func))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -30,6 +29,7 @@
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $closure-class-arrow-this-nested/m (mut i32) (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 512))
  (global $~lib/memory/__data_end i32 (i32.const 544))
@@ -3121,7 +3121,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3179,7 +3179,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $inner
@@ -3192,7 +3192,7 @@
    )
   )
   (return
-   (call_indirect (type $4)
+   (call_indirect (type $5)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3247,7 +3247,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<closure-class-arrow-this-nested/MultiLevel>
@@ -3269,7 +3269,7 @@
    )
   )
   (return
-   (call_indirect (type $4)
+   (call_indirect (type $5)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3362,6 +3362,17 @@
   (if
    (local.tee $1
     (global.get $closure-class-arrow-this-nested/m)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
    )
    (then
     (call $~lib/rt/itcms/__visit

--- a/tests/frontend/compiler/closure-class-arrow-this-setter.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-setter.opt.wat
@@ -18,8 +18,8 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $closure-class-arrow-this-setter/s (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33312))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33312))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -41,6 +41,12 @@
   (local $0 i32)
   (local $1 i32)
   global.get $closure-class-arrow-this-setter/s
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $~lib/rt/closure/env
   local.tee $0
   if
    local.get $0

--- a/tests/frontend/compiler/closure-class-arrow-this-setter.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-setter.wat
@@ -7,12 +7,11 @@
  (type $5 (func))
  (type $6 (func (param i32 i32 i32 i32)))
  (type $7 (func (param i32 i32 i32) (result i32)))
- (type $8 (func (result i32)))
- (type $9 (func (param i32 i32 i64) (result i32)))
+ (type $8 (func (param i32 i32 i64) (result i32)))
+ (type $9 (func (result i32)))
  (type $10 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -30,6 +29,7 @@
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $closure-class-arrow-this-setter/s (mut i32) (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 512))
  (global $~lib/memory/__data_end i32 (i32.const 544))
@@ -3141,7 +3141,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $closure-class-arrow-this-setter/FromSetter#set:stored
@@ -3256,7 +3256,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<closure-class-arrow-this-setter/FromSetter>
@@ -3387,6 +3387,17 @@
   (if
    (local.tee $1
     (global.get $closure-class-arrow-this-setter/s)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
    )
    (then
     (call $~lib/rt/itcms/__visit

--- a/tests/frontend/compiler/closure-class-arrow-this-static.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-static.opt.wat
@@ -40,6 +40,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-class-arrow-this-static.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-static.wat
@@ -3,15 +3,14 @@
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
- (type $4 (func (result i32)))
- (type $5 (func (param i32 i32) (result i32)))
- (type $6 (func))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func))
+ (type $6 (func (result i32)))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
  (type $9 (func (param i32 i32 i64) (result i32)))
  (type $10 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 512))
  (global $~lib/memory/__data_end i32 (i32.const 540))
@@ -3080,7 +3080,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3127,7 +3127,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $getValue
@@ -3140,7 +3140,7 @@
    )
   )
   (return
-   (call_indirect (type $4)
+   (call_indirect (type $6)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3213,7 +3213,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-class-method-arrow.opt.wat
+++ b/tests/frontend/compiler/closure-class-method-arrow.opt.wat
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-class-method-arrow.wat
+++ b/tests/frontend/compiler/closure-class-method-arrow.wat
@@ -5,14 +5,13 @@
  (type $3 (func (param i32 i32 i32)))
  (type $4 (func))
  (type $5 (func (param i32 i32) (result i32)))
- (type $6 (func (result i32)))
- (type $7 (func (param i32 i32 i32 i32)))
- (type $8 (func (param i32 i32 i32) (result i32)))
+ (type $6 (func (param i32 i32 i32 i32)))
+ (type $7 (func (param i32 i32 i32) (result i32)))
+ (type $8 (func (result i32)))
  (type $9 (func (param i32 i32 i64) (result i32)))
  (type $10 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 496))
  (global $~lib/memory/__data_end i32 (i32.const 528))
@@ -3132,7 +3132,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3201,7 +3201,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3332,7 +3332,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-class-method-func.opt.wat
+++ b/tests/frontend/compiler/closure-class-method-func.opt.wat
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-class-method-func.wat
+++ b/tests/frontend/compiler/closure-class-method-func.wat
@@ -5,14 +5,13 @@
  (type $3 (func (param i32 i32 i32)))
  (type $4 (func))
  (type $5 (func (param i32 i32) (result i32)))
- (type $6 (func (result i32)))
- (type $7 (func (param i32 i32 i32 i32)))
- (type $8 (func (param i32 i32 i32) (result i32)))
+ (type $6 (func (param i32 i32 i32 i32)))
+ (type $7 (func (param i32 i32 i32) (result i32)))
+ (type $8 (func (result i32)))
  (type $9 (func (param i32 i32 i64) (result i32)))
  (type $10 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 496))
  (global $~lib/memory/__data_end i32 (i32.const 528))
@@ -3132,7 +3132,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3201,7 +3201,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3334,7 +3334,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-cross-level.opt.wat
+++ b/tests/frontend/compiler/closure-cross-level.opt.wat
@@ -40,6 +40,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-cross-level.wat
+++ b/tests/frontend/compiler/closure-cross-level.wat
@@ -3,8 +3,8 @@
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
- (type $4 (func (result i32)))
- (type $5 (func (param i32 i32) (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (result i32)))
  (type $6 (func))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 480))
  (global $~lib/memory/__data_end i32 (i32.const 508))
@@ -3111,7 +3111,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3176,7 +3176,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3208,7 +3208,7 @@
    )
   )
   (return
-   (call_indirect (type $4)
+   (call_indirect (type $5)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3243,7 +3243,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3265,7 +3265,7 @@
    )
   )
   (return
-   (call_indirect (type $4)
+   (call_indirect (type $5)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3337,7 +3337,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-ffi.opt.wat
+++ b/tests/frontend/compiler/closure-ffi.opt.wat
@@ -20,8 +20,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33392))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33392))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -44,6 +44,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-ffi.wat
+++ b/tests/frontend/compiler/closure-ffi.wat
@@ -4,15 +4,14 @@
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
  (type $4 (func (param i32 i32) (result i32)))
- (type $5 (func (result i32)))
- (type $6 (func))
+ (type $5 (func))
+ (type $6 (func (result i32)))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
  (type $9 (func (param i32 i32 i64) (result i32)))
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "set_ffi_closure_env" (func $~lib/warpo/ffi/ffi.set_ffi_closure_env (param i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
@@ -30,6 +29,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 592))
  (global $~lib/memory/__data_end i32 (i32.const 624))
@@ -3114,7 +3114,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3256,7 +3256,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/warpo/ffi/ffi.set_ffi_closure_env
@@ -3277,7 +3277,7 @@
       (i32.const 4)
      )
     )
-    (call_indirect (type $5)
+    (call_indirect (type $6)
      (block (result i32)
       (call $~lib/rt/closure/setClosureEnv
        (i32.load offset=4
@@ -3389,7 +3389,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<%28%29=>i32>
@@ -3452,7 +3452,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3539,7 +3539,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-functype-param-shadow.opt.wat
+++ b/tests/frontend/compiler/closure-functype-param-shadow.opt.wat
@@ -59,6 +59,12 @@
    local.get $0
    call $~lib/rt/itcms/__visit
   end
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-functype-param-shadow.wat
+++ b/tests/frontend/compiler/closure-functype-param-shadow.wat
@@ -7,13 +7,12 @@
  (type $5 (func))
  (type $6 (func (param i32 i32 i32 i32)))
  (type $7 (func (param i32 i32 i32) (result i32)))
- (type $8 (func (result i32)))
- (type $9 (func (param i32 i32 i64) (result i32)))
+ (type $8 (func (param i32 i32 i64) (result i32)))
+ (type $9 (func (result i32)))
  (type $10 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
  (global $closure-functype-param-shadow/stored (mut i32) (i32.const 0))
@@ -32,6 +31,7 @@
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
  (global $closure-functype-param-shadow/foo (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 736))
  (global $~lib/memory/__data_end i32 (i32.const 772))
  (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33540))
@@ -3116,7 +3116,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $2
@@ -3233,7 +3233,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<closure-functype-param-shadow/C1>
@@ -3410,6 +3410,17 @@
   (if
    (local.tee $1
     (global.get $closure-functype-param-shadow/foo)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
    )
    (then
     (call $~lib/rt/itcms/__visit

--- a/tests/frontend/compiler/closure-loop-early-return.opt.wat
+++ b/tests/frontend/compiler/closure-loop-early-return.opt.wat
@@ -42,6 +42,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-loop-early-return.wat
+++ b/tests/frontend/compiler/closure-loop-early-return.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 496))
  (global $~lib/memory/__data_end i32 (i32.const 524))
@@ -3128,7 +3128,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $sum
@@ -3250,7 +3250,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3329,7 +3329,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $sum
@@ -3419,7 +3419,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3611,7 +3611,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-multi-var.opt.wat
+++ b/tests/frontend/compiler/closure-multi-var.opt.wat
@@ -40,6 +40,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-multi-var.wat
+++ b/tests/frontend/compiler/closure-multi-var.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 480))
  (global $~lib/memory/__data_end i32 (i32.const 508))
@@ -3111,7 +3111,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3177,7 +3177,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3279,7 +3279,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-nested-branch-2level.opt.wat
+++ b/tests/frontend/compiler/closure-nested-branch-2level.opt.wat
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-nested-branch-2level.wat
+++ b/tests/frontend/compiler/closure-nested-branch-2level.wat
@@ -13,7 +13,6 @@
  (type $11 (func (param i32 i32 i32 i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -30,6 +29,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 512))
  (global $~lib/memory/__data_end i32 (i32.const 540))
@@ -3127,7 +3127,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $base
@@ -3284,7 +3284,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3385,7 +3385,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<bool>
@@ -3557,7 +3557,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-nested-branch-3level.opt.wat
+++ b/tests/frontend/compiler/closure-nested-branch-3level.opt.wat
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-nested-branch-3level.wat
+++ b/tests/frontend/compiler/closure-nested-branch-3level.wat
@@ -2,8 +2,8 @@
  (type $0 (func (param i32) (result i32)))
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
- (type $3 (func (result i32)))
- (type $4 (func (param i32 i32 i32)))
+ (type $3 (func (param i32 i32 i32)))
+ (type $4 (func (result i32)))
  (type $5 (func (param i32 i32) (result i32)))
  (type $6 (func))
  (type $7 (func (param i32 i32 i32) (result i32)))
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 512))
  (global $~lib/memory/__data_end i32 (i32.const 540))
@@ -3126,7 +3126,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $base
@@ -3251,7 +3251,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3283,7 +3283,7 @@
    )
   )
   (return
-   (call_indirect (type $3)
+   (call_indirect (type $4)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3318,7 +3318,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3350,7 +3350,7 @@
    )
   )
   (return
-   (call_indirect (type $3)
+   (call_indirect (type $4)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3402,7 +3402,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<bool>
@@ -3438,7 +3438,7 @@
    )
   )
   (return
-   (call_indirect (type $3)
+   (call_indirect (type $4)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3538,7 +3538,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-nested-function-loop.opt.wat
+++ b/tests/frontend/compiler/closure-nested-function-loop.opt.wat
@@ -45,6 +45,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-nested-function-loop.wat
+++ b/tests/frontend/compiler/closure-nested-function-loop.wat
@@ -8,12 +8,11 @@
  (type $6 (func))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
- (type $9 (func (result i32)))
- (type $10 (func (param i32 i32 i64) (result i32)))
+ (type $9 (func (param i32 i32 i64) (result i32)))
+ (type $10 (func (result i32)))
  (type $11 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -32,6 +31,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 640))
  (global $~lib/memory/__data_end i32 (i32.const 668))
@@ -3114,7 +3114,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3204,7 +3204,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3350,7 +3350,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3678,7 +3678,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-nested-loop.opt.wat
+++ b/tests/frontend/compiler/closure-nested-loop.opt.wat
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-nested-loop.wat
+++ b/tests/frontend/compiler/closure-nested-loop.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 480))
  (global $~lib/memory/__data_end i32 (i32.const 508))
@@ -3115,7 +3115,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $sum
@@ -3233,7 +3233,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3312,7 +3312,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $sum
@@ -3380,7 +3380,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3447,7 +3447,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3618,7 +3618,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-nested.opt.wat
+++ b/tests/frontend/compiler/closure-nested.opt.wat
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-nested.wat
+++ b/tests/frontend/compiler/closure-nested.wat
@@ -3,8 +3,8 @@
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
- (type $4 (func (result i32)))
- (type $5 (func (param i32 i32) (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (result i32)))
  (type $6 (func))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 480))
  (global $~lib/memory/__data_end i32 (i32.const 508))
@@ -3111,7 +3111,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3169,7 +3169,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3201,7 +3201,7 @@
    )
   )
   (return
-   (call_indirect (type $4)
+   (call_indirect (type $5)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3236,7 +3236,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3258,7 +3258,7 @@
    )
   )
   (return
-   (call_indirect (type $4)
+   (call_indirect (type $5)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3330,7 +3330,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-obj-attribute.opt.wat
+++ b/tests/frontend/compiler/closure-obj-attribute.opt.wat
@@ -18,8 +18,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33296))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33296))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -42,6 +42,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-obj-attribute.wat
+++ b/tests/frontend/compiler/closure-obj-attribute.wat
@@ -5,14 +5,13 @@
  (type $3 (func (param i32 i32 i32)))
  (type $4 (func))
  (type $5 (func (param i32 i32) (result i32)))
- (type $6 (func (result i32)))
- (type $7 (func (param i32 i32 i32 i32)))
- (type $8 (func (param i32 i32 i32) (result i32)))
+ (type $6 (func (param i32 i32 i32 i32)))
+ (type $7 (func (param i32 i32 i32) (result i32)))
+ (type $8 (func (result i32)))
  (type $9 (func (param i32 i32 i64) (result i32)))
  (type $10 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 496))
  (global $~lib/memory/__data_end i32 (i32.const 528))
@@ -3153,7 +3153,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $closure-obj-attribute/Point#set:x
@@ -3252,7 +3252,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<closure-obj-attribute/Point>
@@ -3397,7 +3397,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-obj-reassign.opt.wat
+++ b/tests/frontend/compiler/closure-obj-reassign.opt.wat
@@ -42,6 +42,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-obj-reassign.wat
+++ b/tests/frontend/compiler/closure-obj-reassign.wat
@@ -5,14 +5,13 @@
  (type $3 (func (param i32 i32 i32)))
  (type $4 (func))
  (type $5 (func (param i32 i32) (result i32)))
- (type $6 (func (result i32)))
- (type $7 (func (param i32 i32 i32 i32)))
- (type $8 (func (param i32 i32 i32) (result i32)))
+ (type $6 (func (param i32 i32 i32 i32)))
+ (type $7 (func (param i32 i32 i32) (result i32)))
+ (type $8 (func (result i32)))
  (type $9 (func (param i32 i32 i64) (result i32)))
  (type $10 (func (param i32 i64) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 496))
  (global $~lib/memory/__data_end i32 (i32.const 528))
@@ -3138,7 +3138,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $newObj
@@ -3217,7 +3217,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<closure-obj-reassign/Box>
@@ -3339,7 +3339,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-param-nested.opt.wat
+++ b/tests/frontend/compiler/closure-param-nested.opt.wat
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-param-nested.wat
+++ b/tests/frontend/compiler/closure-param-nested.wat
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 496))
  (global $~lib/memory/__data_end i32 (i32.const 528))
@@ -3095,7 +3095,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3175,7 +3175,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3231,7 +3231,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3326,7 +3326,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-param.opt.wat
+++ b/tests/frontend/compiler/closure-param.opt.wat
@@ -18,8 +18,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33276))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33276))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-param.wat
+++ b/tests/frontend/compiler/closure-param.wat
@@ -4,15 +4,14 @@
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32) (result i32)))
  (type $4 (func (param i32 i32 i32)))
- (type $5 (func (result i32)))
- (type $6 (func))
+ (type $5 (func))
+ (type $6 (func (result i32)))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
  (type $9 (func (param i32 i32 i64) (result i32)))
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 480))
  (global $~lib/memory/__data_end i32 (i32.const 508))
@@ -3111,7 +3111,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3197,7 +3197,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3231,7 +3231,7 @@
    )
   )
   (local.set $a
-   (call_indirect (type $5)
+   (call_indirect (type $6)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3248,7 +3248,7 @@
    )
   )
   (local.set $b
-   (call_indirect (type $5)
+   (call_indirect (type $6)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3330,7 +3330,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-set-var.opt.wat
+++ b/tests/frontend/compiler/closure-set-var.opt.wat
@@ -18,8 +18,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33276))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33276))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-set-var.wat
+++ b/tests/frontend/compiler/closure-set-var.wat
@@ -7,12 +7,11 @@
  (type $5 (func (param i32 i32) (result i32)))
  (type $6 (func (param i32 i32 i32 i32)))
  (type $7 (func (param i32 i32 i32) (result i32)))
- (type $8 (func (result i32)))
- (type $9 (func (param i32 i32 i64) (result i32)))
+ (type $8 (func (param i32 i32 i64) (result i32)))
+ (type $9 (func (result i32)))
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 480))
  (global $~lib/memory/__data_end i32 (i32.const 508))
@@ -3111,7 +3111,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3175,7 +3175,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3290,7 +3290,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-skip-level.opt.wat
+++ b/tests/frontend/compiler/closure-skip-level.opt.wat
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-skip-level.wat
+++ b/tests/frontend/compiler/closure-skip-level.wat
@@ -3,8 +3,8 @@
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
- (type $4 (func (result i32)))
- (type $5 (func (param i32 i32) (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (result i32)))
  (type $6 (func))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 480))
  (global $~lib/memory/__data_end i32 (i32.const 508))
@@ -3111,7 +3111,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3169,7 +3169,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (local.set $y
@@ -3188,7 +3188,7 @@
   )
   (return
    (i32.add
-    (call_indirect (type $4)
+    (call_indirect (type $5)
      (block (result i32)
       (call $~lib/rt/closure/setClosureEnv
        (i32.load offset=4
@@ -3225,7 +3225,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3247,7 +3247,7 @@
    )
   )
   (return
-   (call_indirect (type $4)
+   (call_indirect (type $5)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3319,7 +3319,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-template.opt.wat
+++ b/tests/frontend/compiler/closure-template.opt.wat
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-template.wat
+++ b/tests/frontend/compiler/closure-template.wat
@@ -16,7 +16,6 @@
  (type $14 (func (param f32) (result f32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -33,6 +32,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 480))
  (global $~lib/memory/__data_end i32 (i32.const 512))
@@ -3114,7 +3114,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3169,7 +3169,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3254,7 +3254,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3286,7 +3286,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<f32>
@@ -3404,7 +3404,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-tmp-function.opt.wat
+++ b/tests/frontend/compiler/closure-tmp-function.opt.wat
@@ -1,0 +1,1756 @@
+(module
+ (type $0 (func (result i32)))
+ (type $1 (func))
+ (type $2 (func (param i32)))
+ (type $3 (func (param i32 i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (param i32 i32 i32 i32)))
+ (type $6 (func (param i32 i32 i32)))
+ (type $7 (func (param i32 i32 i64)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (global $~lib/rt/itcms/toSpace (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/visitCount (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/pinSpace (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/iter (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
+ (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (memory $0 1)
+ (data $0 (i32.const 12) "<")
+ (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
+ (data $1.1 (i32.const 88) "\02\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s")
+ (data $4 (i32.const 204) "<")
+ (data $4.1 (i32.const 216) "\02\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e")
+ (data $5 (i32.const 268) ",")
+ (data $5.1 (i32.const 280) "\02\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s")
+ (data $7 (i32.const 348) "<")
+ (data $7.1 (i32.const 360) "\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
+ (data $8 (i32.const 412) "L")
+ (data $8.1 (i32.const 424) "\02\00\00\00.\00\00\00c\00l\00o\00s\00u\00r\00e\00-\00t\00m\00p\00-\00f\00u\00n\00c\00t\00i\00o\00n\00.\00t\00s")
+ (data $9 (i32.const 496) "\06\00\00\00 \00\00\00 \00\00\00 ")
+ (table $0 2 2 funcref)
+ (elem $0 (i32.const 1) $closure-tmp-function/getFunction~anonymous|0)
+ (export "getFunction" (func $closure-tmp-function/getFunction))
+ (export "foo" (func $closure-tmp-function/foo))
+ (export "memory" (memory $0))
+ (start $~start)
+ (func $~lib/rt/itcms/visitRoots
+  (local $0 i32)
+  (local $1 i32)
+  global.get $~lib/rt/itcms/pinSpace
+  local.tee $1
+  i32.load offset=4
+  i32.const -4
+  i32.and
+  local.set $0
+  loop $while-continue|0
+   local.get $0
+   local.get $1
+   i32.ne
+   if
+    local.get $0
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.const 3
+    i32.ne
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 159
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    i32.const 20
+    i32.add
+    call $~lib/rt/__visit_members
+    local.get $0
+    i32.load offset=4
+    i32.const -4
+    i32.and
+    local.set $0
+    br $while-continue|0
+   end
+  end
+ )
+ (func $~lib/rt/itcms/Object#linkTo (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  i32.load offset=8
+  local.set $3
+  local.get $0
+  local.get $1
+  local.get $2
+  i32.or
+  i32.store offset=4
+  local.get $0
+  local.get $3
+  i32.store offset=8
+  local.get $3
+  local.get $0
+  local.get $3
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  i32.or
+  i32.store offset=4
+  local.get $1
+  local.get $0
+  i32.store offset=8
+ )
+ (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  local.get $0
+  global.get $~lib/rt/itcms/iter
+  i32.eq
+  if
+   local.get $0
+   i32.load offset=8
+   local.tee $1
+   if (result i32)
+    local.get $1
+   else
+    i32.const 0
+    i32.const 96
+    i32.const 147
+    i32.const 30
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.set $~lib/rt/itcms/iter
+  end
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$82
+   local.get $0
+   i32.load offset=4
+   i32.const -4
+   i32.and
+   local.tee $2
+   i32.eqz
+   if
+    local.get $0
+    i32.load offset=8
+    i32.eqz
+    local.get $0
+    i32.const 33292
+    i32.lt_u
+    i32.and
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 96
+     i32.const 127
+     i32.const 18
+     call $~lib/builtins/abort
+     unreachable
+    end
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$82
+   end
+   local.get $0
+   i32.load offset=8
+   local.tee $1
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 96
+    i32.const 131
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $2
+   local.get $1
+   i32.store offset=8
+   local.get $1
+   local.get $2
+   local.get $1
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   i32.or
+   i32.store offset=4
+  end
+  local.get $0
+  global.get $~lib/rt/itcms/toSpace
+  local.get $0
+  i32.load offset=12
+  local.tee $0
+  i32.const 2
+  i32.le_u
+  if (result i32)
+   i32.const 1
+  else
+   local.get $0
+   i32.const 496
+   i32.load
+   i32.gt_u
+   if
+    i32.const 224
+    i32.const 288
+    i32.const 22
+    i32.const 28
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   i32.const 2
+   i32.shl
+   i32.const 500
+   i32.add
+   i32.load
+   i32.const 32
+   i32.and
+  end
+  if (result i32)
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+  else
+   i32.const 2
+  end
+  call $~lib/rt/itcms/Object#linkTo
+ )
+ (func $~lib/rt/itcms/__visit (param $0 i32)
+  local.get $0
+  if
+   global.get $~lib/rt/itcms/white
+   local.get $0
+   i32.const 20
+   i32.sub
+   local.tee $0
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   i32.eq
+   if
+    local.get $0
+    call $~lib/rt/itcms/Object#makeGray
+    global.get $~lib/rt/itcms/visitCount
+    i32.const 1
+    i32.add
+    global.set $~lib/rt/itcms/visitCount
+   end
+  end
+ )
+ (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.load
+  local.tee $2
+  i32.const 1
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 245
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const -4
+  i32.and
+  local.tee $2
+  i32.const 12
+  i32.lt_u
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 247
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $2
+  i32.const 256
+  i32.lt_u
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shr_u
+   local.set $3
+   i32.const 0
+  else
+   i32.const 31
+   i32.const 1073741820
+   local.get $2
+   local.get $2
+   i32.const 1073741820
+   i32.ge_u
+   select
+   local.tee $3
+   i32.clz
+   i32.sub
+   local.set $2
+   local.get $3
+   local.get $2
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+   local.set $3
+   local.get $2
+   i32.const 7
+   i32.sub
+  end
+  local.set $4
+  local.get $3
+  i32.const 16
+  i32.lt_u
+  local.get $4
+  i32.const 23
+  i32.lt_u
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 261
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.load offset=8
+  local.set $2
+  local.get $1
+  i32.load offset=4
+  local.tee $5
+  if
+   local.get $5
+   local.get $2
+   i32.store offset=8
+  end
+  local.get $2
+  if
+   local.get $2
+   local.get $5
+   i32.store offset=4
+  end
+  local.get $1
+  local.get $0
+  local.get $4
+  i32.const 4
+  i32.shl
+  local.get $3
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  local.tee $5
+  i32.load offset=96
+  i32.eq
+  if
+   local.get $5
+   local.get $2
+   i32.store offset=96
+   local.get $2
+   i32.eqz
+   if
+    local.get $0
+    local.get $4
+    i32.const 2
+    i32.shl
+    i32.add
+    local.tee $1
+    local.get $1
+    i32.load offset=4
+    i32.const -2
+    local.get $3
+    i32.rotl
+    i32.and
+    local.tee $1
+    i32.store offset=4
+    local.get $1
+    i32.eqz
+    if
+     local.get $0
+     local.get $0
+     i32.load
+     i32.const -2
+     local.get $4
+     i32.rotl
+     i32.and
+     i32.store
+    end
+   end
+  end
+ )
+ (func $~lib/rt/tlsf/insertBlock (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $1
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 178
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.load
+  local.tee $2
+  i32.const 1
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 180
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $1
+  i32.const 4
+  i32.add
+  local.tee $5
+  local.get $1
+  i32.load
+  i32.const -4
+  i32.and
+  i32.add
+  local.tee $3
+  i32.load
+  local.tee $4
+  i32.const 1
+  i32.and
+  if
+   local.get $0
+   local.get $3
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $2
+   i32.const 4
+   i32.add
+   local.get $4
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $2
+   i32.store
+   local.get $1
+   i32.load
+   i32.const -4
+   i32.and
+   local.get $5
+   i32.add
+   local.tee $3
+   i32.load
+   local.set $4
+  end
+  local.get $2
+  i32.const 2
+  i32.and
+  if
+   local.get $1
+   i32.const 4
+   i32.sub
+   i32.load
+   local.tee $1
+   i32.load
+   local.tee $5
+   i32.const 1
+   i32.and
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 368
+    i32.const 198
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/removeBlock
+   local.get $1
+   local.get $5
+   i32.const 4
+   i32.add
+   local.get $2
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $2
+   i32.store
+  end
+  local.get $3
+  local.get $4
+  i32.const 2
+  i32.or
+  i32.store
+  local.get $2
+  i32.const -4
+  i32.and
+  local.tee $2
+  i32.const 12
+  i32.lt_u
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 210
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  local.get $1
+  i32.const 4
+  i32.add
+  local.get $2
+  i32.add
+  i32.ne
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 211
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $3
+  i32.const 4
+  i32.sub
+  local.get $1
+  i32.store
+  local.get $2
+  i32.const 256
+  i32.lt_u
+  if (result i32)
+   local.get $2
+   i32.const 4
+   i32.shr_u
+   local.set $3
+   i32.const 0
+  else
+   i32.const 31
+   i32.const 1073741820
+   local.get $2
+   local.get $2
+   i32.const 1073741820
+   i32.ge_u
+   select
+   local.tee $3
+   i32.clz
+   i32.sub
+   local.set $2
+   local.get $3
+   local.get $2
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+   local.set $3
+   local.get $2
+   i32.const 7
+   i32.sub
+  end
+  local.set $2
+  local.get $3
+  i32.const 16
+  i32.lt_u
+  local.get $2
+  i32.const 23
+  i32.lt_u
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 228
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $2
+  i32.const 4
+  i32.shl
+  local.get $3
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=96
+  local.set $4
+  local.get $1
+  i32.const 0
+  i32.store offset=4
+  local.get $1
+  local.get $4
+  i32.store offset=8
+  local.get $4
+  if
+   local.get $4
+   local.get $1
+   i32.store offset=4
+  end
+  local.get $0
+  local.get $2
+  i32.const 4
+  i32.shl
+  local.get $3
+  i32.add
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $1
+  i32.store offset=96
+  local.get $0
+  local.get $0
+  i32.load
+  i32.const 1
+  local.get $2
+  i32.shl
+  i32.or
+  i32.store
+  local.get $0
+  local.get $2
+  i32.const 2
+  i32.shl
+  i32.add
+  local.tee $0
+  local.get $0
+  i32.load offset=4
+  i32.const 1
+  local.get $3
+  i32.shl
+  i32.or
+  i32.store offset=4
+ )
+ (func $~lib/rt/tlsf/addMemory (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  block $CONDITION_RETURN#0
+   local.get $2
+   local.get $1
+   i64.extend_i32_u
+   i64.lt_u
+   if
+    i32.const 0
+    i32.const 368
+    i32.const 357
+    i32.const 14
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   i32.const 19
+   i32.add
+   i32.const -16
+   i32.and
+   i32.const 4
+   i32.sub
+   local.set $1
+   local.get $0
+   i32.load offset=1568
+   local.tee $4
+   if
+    local.get $4
+    i32.const 4
+    i32.add
+    local.get $1
+    i32.gt_u
+    if
+     i32.const 0
+     i32.const 368
+     i32.const 365
+     i32.const 16
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $1
+    i32.const 16
+    i32.sub
+    local.tee $3
+    local.get $4
+    i32.eq
+    if
+     local.get $4
+     i32.load
+     local.set $5
+     local.get $3
+     local.set $1
+    end
+   else
+    local.get $0
+    i32.const 1572
+    i32.add
+    local.get $1
+    i32.gt_u
+    if
+     i32.const 0
+     i32.const 368
+     i32.const 378
+     i32.const 5
+     call $~lib/builtins/abort
+     unreachable
+    end
+   end
+   local.get $2
+   i32.wrap_i64
+   i32.const -16
+   i32.and
+   local.get $1
+   i32.sub
+   local.tee $3
+   i32.const 20
+   i32.lt_u
+   br_if $CONDITION_RETURN#0
+   local.get $1
+   local.get $5
+   i32.const 2
+   i32.and
+   local.get $3
+   i32.const 8
+   i32.sub
+   local.tee $3
+   i32.const 1
+   i32.or
+   i32.or
+   i32.store
+   local.get $1
+   i32.const 0
+   i32.store offset=4
+   local.get $1
+   i32.const 0
+   i32.store offset=8
+   local.get $1
+   i32.const 4
+   i32.add
+   local.get $3
+   i32.add
+   local.tee $3
+   i32.const 2
+   i32.store
+   local.get $0
+   local.get $3
+   i32.store offset=1568
+   local.get $0
+   local.get $1
+   call $~lib/rt/tlsf/insertBlock
+  end
+ )
+ (func $~lib/rt/tlsf/initialize
+  (local $0 i32)
+  (local $1 i32)
+  memory.size
+  local.tee $0
+  i32.const 0
+  i32.le_s
+  if (result i32)
+   i32.const 1
+   local.get $0
+   i32.sub
+   memory.grow
+   i32.const 0
+   i32.lt_s
+  else
+   i32.const 0
+  end
+  if
+   unreachable
+  end
+  i32.const 33296
+  i32.const 0
+  i32.store
+  i32.const 34864
+  i32.const 0
+  i32.store
+  i32.const 0
+  local.set $0
+  loop $for-loop|0
+   local.get $0
+   i32.const 23
+   i32.lt_u
+   if
+    local.get $0
+    i32.const 2
+    i32.shl
+    i32.const 33296
+    i32.add
+    i32.const 0
+    i32.store offset=4
+    i32.const 0
+    local.set $1
+    loop $for-loop|1
+     local.get $1
+     i32.const 16
+     i32.lt_u
+     if
+      local.get $0
+      i32.const 4
+      i32.shl
+      local.get $1
+      i32.add
+      i32.const 2
+      i32.shl
+      i32.const 33296
+      i32.add
+      i32.const 0
+      i32.store offset=96
+      local.get $1
+      i32.const 1
+      i32.add
+      local.set $1
+      br $for-loop|1
+     end
+    end
+    local.get $0
+    i32.const 1
+    i32.add
+    local.set $0
+    br $for-loop|0
+   end
+  end
+  i32.const 33296
+  i32.const 34868
+  memory.size
+  i64.extend_i32_s
+  i64.const 16
+  i64.shl
+  call $~lib/rt/tlsf/addMemory
+  i32.const 33296
+  global.set $~lib/rt/tlsf/ROOT
+ )
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  local.get $1
+  i32.const 256
+  i32.lt_u
+  if (result i32)
+   local.get $1
+   i32.const 4
+   i32.shr_u
+   local.set $1
+   i32.const 0
+  else
+   i32.const 31
+   local.get $1
+   i32.const 1
+   i32.const 27
+   local.get $1
+   i32.clz
+   i32.sub
+   i32.shl
+   i32.add
+   i32.const 1
+   i32.sub
+   local.get $1
+   local.get $1
+   i32.const 536870910
+   i32.lt_u
+   select
+   local.tee $1
+   i32.clz
+   i32.sub
+   local.set $2
+   local.get $1
+   local.get $2
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+   local.set $1
+   local.get $2
+   i32.const 7
+   i32.sub
+  end
+  local.set $2
+  local.get $1
+  i32.const 16
+  i32.lt_u
+  local.get $2
+  i32.const 23
+  i32.lt_u
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 309
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $0
+  local.get $2
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load offset=4
+  i32.const -1
+  local.get $1
+  i32.shl
+  i32.and
+  local.tee $1
+  if (result i32)
+   local.get $0
+   local.get $1
+   i32.ctz
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.add
+   i32.const 2
+   i32.shl
+   i32.add
+   i32.load offset=96
+  else
+   local.get $0
+   i32.load
+   i32.const -1
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.shl
+   i32.and
+   local.tee $1
+   if (result i32)
+    local.get $0
+    local.get $1
+    i32.ctz
+    local.tee $1
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=4
+    local.tee $2
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 368
+     i32.const 322
+     i32.const 18
+     call $~lib/builtins/abort
+     unreachable
+    end
+    local.get $0
+    local.get $2
+    i32.ctz
+    local.get $1
+    i32.const 4
+    i32.shl
+    i32.add
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=96
+   else
+    i32.const 0
+   end
+  end
+ )
+ (func $~lib/rt/itcms/__new (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.const 1073741804
+  i32.ge_u
+  if
+   i32.const 32
+   i32.const 96
+   i32.const 262
+   i32.const 31
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/itcms/total
+  global.get $~lib/rt/itcms/threshold
+  i32.ge_u
+  if
+   block $__inlined_func$~lib/rt/itcms/interrupt$67
+    i32.const 2048
+    local.set $2
+    loop $do-loop|0
+     local.get $2
+     block $__inlined_func$~lib/rt/itcms/step$87 (result i32)
+      block $break|0
+       block $case2|0
+        block $case1|0
+         block $case0|0
+          global.get $~lib/rt/itcms/state
+          br_table $case0|0 $case1|0 $case2|0 $break|0
+         end
+         i32.const 1
+         global.set $~lib/rt/itcms/state
+         i32.const 0
+         global.set $~lib/rt/itcms/visitCount
+         call $~lib/rt/itcms/visitRoots
+         global.get $~lib/rt/itcms/toSpace
+         global.set $~lib/rt/itcms/iter
+         global.get $~lib/rt/itcms/visitCount
+         br $__inlined_func$~lib/rt/itcms/step$87
+        end
+        global.get $~lib/rt/itcms/white
+        i32.eqz
+        local.set $4
+        global.get $~lib/rt/itcms/iter
+        i32.load offset=4
+        i32.const -4
+        i32.and
+        local.set $2
+        loop $while-continue|1
+         local.get $2
+         global.get $~lib/rt/itcms/toSpace
+         i32.ne
+         if
+          local.get $2
+          global.set $~lib/rt/itcms/iter
+          local.get $4
+          local.get $2
+          i32.load offset=4
+          i32.const 3
+          i32.and
+          i32.ne
+          if
+           local.get $2
+           local.get $2
+           i32.load offset=4
+           i32.const -4
+           i32.and
+           local.get $4
+           i32.or
+           i32.store offset=4
+           i32.const 0
+           global.set $~lib/rt/itcms/visitCount
+           local.get $2
+           i32.const 20
+           i32.add
+           call $~lib/rt/__visit_members
+           global.get $~lib/rt/itcms/visitCount
+           br $__inlined_func$~lib/rt/itcms/step$87
+          end
+          local.get $2
+          i32.load offset=4
+          i32.const -4
+          i32.and
+          local.set $2
+          br $while-continue|1
+         end
+        end
+        i32.const 0
+        global.set $~lib/rt/itcms/visitCount
+        call $~lib/rt/itcms/visitRoots
+        global.get $~lib/rt/itcms/toSpace
+        global.get $~lib/rt/itcms/iter
+        i32.load offset=4
+        i32.const -4
+        i32.and
+        i32.eq
+        if
+         i32.const 33292
+         local.set $2
+         loop $while-continue|0
+          local.get $2
+          i32.const 33292
+          i32.lt_u
+          if
+           local.get $2
+           i32.load
+           call $~lib/rt/itcms/__visit
+           local.get $2
+           i32.const 4
+           i32.add
+           local.set $2
+           br $while-continue|0
+          end
+         end
+         global.get $~lib/rt/itcms/iter
+         i32.load offset=4
+         i32.const -4
+         i32.and
+         local.set $2
+         loop $while-continue|2
+          local.get $2
+          global.get $~lib/rt/itcms/toSpace
+          i32.ne
+          if
+           local.get $4
+           local.get $2
+           i32.load offset=4
+           i32.const 3
+           i32.and
+           i32.ne
+           if
+            local.get $2
+            local.get $2
+            i32.load offset=4
+            i32.const -4
+            i32.and
+            local.get $4
+            i32.or
+            i32.store offset=4
+            local.get $2
+            i32.const 20
+            i32.add
+            call $~lib/rt/__visit_members
+           end
+           local.get $2
+           i32.load offset=4
+           i32.const -4
+           i32.and
+           local.set $2
+           br $while-continue|2
+          end
+         end
+         global.get $~lib/rt/itcms/fromSpace
+         local.set $3
+         global.get $~lib/rt/itcms/toSpace
+         global.set $~lib/rt/itcms/fromSpace
+         local.get $3
+         global.set $~lib/rt/itcms/toSpace
+         local.get $4
+         global.set $~lib/rt/itcms/white
+         local.get $3
+         i32.load offset=4
+         i32.const -4
+         i32.and
+         global.set $~lib/rt/itcms/iter
+         i32.const 2
+         global.set $~lib/rt/itcms/state
+        end
+        global.get $~lib/rt/itcms/visitCount
+        br $__inlined_func$~lib/rt/itcms/step$87
+       end
+       global.get $~lib/rt/itcms/iter
+       local.tee $3
+       global.get $~lib/rt/itcms/toSpace
+       i32.ne
+       if
+        local.get $3
+        i32.load offset=4
+        i32.const -4
+        i32.and
+        global.set $~lib/rt/itcms/iter
+        global.get $~lib/rt/itcms/white
+        i32.eqz
+        local.get $3
+        i32.load offset=4
+        i32.const 3
+        i32.and
+        i32.ne
+        if
+         i32.const 0
+         i32.const 96
+         i32.const 229
+         i32.const 20
+         call $~lib/builtins/abort
+         unreachable
+        end
+        local.get $3
+        i32.const 33292
+        i32.lt_u
+        if
+         local.get $3
+         i32.const 0
+         i32.store offset=4
+         local.get $3
+         i32.const 0
+         i32.store offset=8
+        else
+         global.get $~lib/rt/itcms/total
+         local.get $3
+         i32.load
+         i32.const -4
+         i32.and
+         i32.const 4
+         i32.add
+         i32.sub
+         global.set $~lib/rt/itcms/total
+         local.get $3
+         i32.const 4
+         i32.add
+         local.tee $2
+         i32.const 33292
+         i32.ge_u
+         if
+          global.get $~lib/rt/tlsf/ROOT
+          i32.eqz
+          if
+           call $~lib/rt/tlsf/initialize
+          end
+          global.get $~lib/rt/tlsf/ROOT
+          local.set $3
+          local.get $2
+          i32.const 4
+          i32.sub
+          local.set $4
+          local.get $2
+          i32.const 15
+          i32.and
+          i32.const 1
+          local.get $2
+          select
+          if (result i32)
+           i32.const 1
+          else
+           local.get $4
+           i32.load
+           i32.const 1
+           i32.and
+          end
+          if
+           i32.const 0
+           i32.const 368
+           i32.const 532
+           i32.const 3
+           call $~lib/builtins/abort
+           unreachable
+          end
+          local.get $4
+          local.get $4
+          i32.load
+          i32.const 1
+          i32.or
+          i32.store
+          local.get $3
+          local.get $4
+          call $~lib/rt/tlsf/insertBlock
+         end
+        end
+        i32.const 10
+        br $__inlined_func$~lib/rt/itcms/step$87
+       end
+       global.get $~lib/rt/itcms/toSpace
+       global.get $~lib/rt/itcms/toSpace
+       i32.store offset=4
+       global.get $~lib/rt/itcms/toSpace
+       global.get $~lib/rt/itcms/toSpace
+       i32.store offset=8
+       i32.const 0
+       global.set $~lib/rt/itcms/state
+      end
+      i32.const 0
+     end
+     i32.sub
+     local.set $2
+     global.get $~lib/rt/itcms/state
+     i32.eqz
+     if
+      global.get $~lib/rt/itcms/total
+      i32.const 1
+      i32.shl
+      i32.const 1024
+      i32.add
+      global.set $~lib/rt/itcms/threshold
+      br $__inlined_func$~lib/rt/itcms/interrupt$67
+     end
+     local.get $2
+     i32.const 0
+     i32.gt_s
+     br_if $do-loop|0
+    end
+    global.get $~lib/rt/itcms/total
+    global.get $~lib/rt/itcms/total
+    global.get $~lib/rt/itcms/threshold
+    i32.sub
+    i32.const 1024
+    i32.lt_u
+    i32.const 10
+    i32.shl
+    i32.add
+    global.set $~lib/rt/itcms/threshold
+   end
+  end
+  global.get $~lib/rt/tlsf/ROOT
+  i32.eqz
+  if
+   call $~lib/rt/tlsf/initialize
+  end
+  global.get $~lib/rt/tlsf/ROOT
+  local.set $5
+  local.get $0
+  i32.const 16
+  i32.add
+  local.tee $3
+  i32.const 1073741820
+  i32.gt_u
+  if
+   i32.const 32
+   i32.const 368
+   i32.const 435
+   i32.const 29
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  i32.const 12
+  local.get $3
+  i32.const 19
+  i32.add
+  i32.const -16
+  i32.and
+  i32.const 4
+  i32.sub
+  local.get $3
+  i32.const 12
+  i32.le_u
+  select
+  local.tee $3
+  call $~lib/rt/tlsf/searchBlock
+  local.tee $2
+  i32.eqz
+  if
+   local.get $3
+   local.tee $2
+   i32.const 256
+   i32.ge_u
+   if (result i32)
+    local.get $2
+    i32.const 1
+    i32.const 27
+    local.get $2
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.get $2
+    local.get $2
+    i32.const 536870910
+    i32.lt_u
+    select
+   else
+    local.get $2
+   end
+   i32.const 4
+   local.get $5
+   i32.load offset=1568
+   memory.size
+   local.tee $4
+   i32.const 16
+   i32.shl
+   i32.const 4
+   i32.sub
+   i32.ne
+   i32.shl
+   i32.add
+   i32.const 65535
+   i32.add
+   i32.const -65536
+   i32.and
+   i32.const 16
+   i32.shr_u
+   local.set $2
+   local.get $4
+   local.get $2
+   local.get $2
+   local.get $4
+   i32.lt_s
+   select
+   memory.grow
+   i32.const 0
+   i32.lt_s
+   if
+    local.get $2
+    memory.grow
+    i32.const 0
+    i32.lt_s
+    if
+     unreachable
+    end
+   end
+   local.get $5
+   local.get $4
+   i32.const 16
+   i32.shl
+   memory.size
+   i64.extend_i32_s
+   i64.const 16
+   i64.shl
+   call $~lib/rt/tlsf/addMemory
+   local.get $5
+   local.get $3
+   call $~lib/rt/tlsf/searchBlock
+   local.tee $2
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 368
+    i32.const 472
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+  end
+  local.get $3
+  local.get $2
+  i32.load
+  i32.const -4
+  i32.and
+  i32.gt_u
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 474
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $5
+  local.get $2
+  call $~lib/rt/tlsf/removeBlock
+  local.get $2
+  i32.load
+  local.set $6
+  local.get $3
+  i32.const 4
+  i32.add
+  i32.const 15
+  i32.and
+  if
+   i32.const 0
+   i32.const 368
+   i32.const 336
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
+  i32.const -4
+  i32.and
+  local.get $3
+  i32.sub
+  local.tee $4
+  i32.const 16
+  i32.ge_u
+  if
+   local.get $2
+   local.get $3
+   local.get $6
+   i32.const 2
+   i32.and
+   i32.or
+   i32.store
+   local.get $2
+   i32.const 4
+   i32.add
+   local.get $3
+   i32.add
+   local.tee $3
+   local.get $4
+   i32.const 4
+   i32.sub
+   i32.const 1
+   i32.or
+   i32.store
+   local.get $5
+   local.get $3
+   call $~lib/rt/tlsf/insertBlock
+  else
+   local.get $2
+   local.get $6
+   i32.const -2
+   i32.and
+   i32.store
+   local.get $2
+   i32.const 4
+   i32.add
+   local.get $2
+   i32.load
+   i32.const -4
+   i32.and
+   i32.add
+   local.tee $3
+   local.get $3
+   i32.load
+   i32.const -3
+   i32.and
+   i32.store
+  end
+  local.get $2
+  local.get $1
+  i32.store offset=12
+  local.get $2
+  local.get $0
+  i32.store offset=16
+  local.get $2
+  global.get $~lib/rt/itcms/fromSpace
+  global.get $~lib/rt/itcms/white
+  call $~lib/rt/itcms/Object#linkTo
+  global.get $~lib/rt/itcms/total
+  local.get $2
+  i32.load
+  i32.const -4
+  i32.and
+  i32.const 4
+  i32.add
+  i32.add
+  global.set $~lib/rt/itcms/total
+  local.get $2
+  i32.const 20
+  i32.add
+  local.tee $1
+  i32.const 0
+  local.get $0
+  memory.fill
+  local.get $1
+ )
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $1
+  if
+   local.get $0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 96
+    i32.const 296
+    i32.const 14
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/rt/itcms/white
+   local.get $1
+   i32.const 20
+   i32.sub
+   local.tee $1
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   i32.eq
+   if
+    local.get $0
+    i32.const 20
+    i32.sub
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    local.tee $0
+    global.get $~lib/rt/itcms/white
+    i32.eqz
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     global.get $~lib/rt/itcms/state
+     i32.const 1
+     i32.eq
+     local.get $0
+     i32.const 3
+     i32.eq
+     i32.and
+     if
+      local.get $1
+      call $~lib/rt/itcms/Object#makeGray
+     end
+    end
+   end
+  end
+ )
+ (func $closure-tmp-function/getFunction~anonymous|0 (result i32)
+  (local $0 i32)
+  i32.const 12
+  i32.const 4
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.const 4
+  i32.add
+  i64.const 1
+  i64.store
+  local.get $0
+  global.get $~lib/rt/closure/env
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  local.get $0
+  i32.load
+  i32.const 4
+  i32.add
+  i32.load
+  i32.const 1
+  i32.add
+ )
+ (func $closure-tmp-function/getFunction (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  i32.const 16
+  i32.const 4
+  call $~lib/rt/itcms/__new
+  local.tee $0
+  i32.const 8
+  i32.add
+  i64.const 1
+  i64.store
+  local.get $0
+  global.get $~lib/rt/closure/env
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  local.get $0
+  i32.const 4
+  i32.add
+  i32.const 5
+  i32.store
+  i32.const 8
+  i32.const 5
+  call $~lib/rt/itcms/__new
+  local.tee $1
+  i32.const 1
+  i32.store
+  local.get $1
+  i32.const 4
+  i32.add
+  local.get $0
+  i32.store
+  local.get $1
+ )
+ (func $closure-tmp-function/foo (result i32)
+  (local $0 i32)
+  i32.const 0
+  global.set $~lib/rt/closure/env
+  call $closure-tmp-function/getFunction
+  local.tee $0
+  i32.load offset=4
+  global.set $~lib/rt/closure/env
+  local.get $0
+  i32.load
+  call_indirect (type $0)
+ )
+ (func $~lib/rt/__visit_members (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i64)
+  block $invalid
+   block $~lib/function/Function<%28%29=>i32>
+    block $~lib/tuple/SmallTuple
+     block $~lib/arraybuffer/ArrayBufferView
+      block $~lib/string/String
+       local.get $0
+       i32.const 8
+       i32.sub
+       i32.load
+       br_table $~lib/string/String $~lib/string/String $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/tuple/SmallTuple $~lib/function/Function<%28%29=>i32> $invalid
+      end
+      return
+     end
+     local.get $0
+     i32.load
+     call $~lib/rt/itcms/__visit
+     return
+    end
+    local.get $0
+    i32.const 20
+    i32.sub
+    i32.load offset=16
+    local.tee $1
+    i32.const 8
+    i32.sub
+    i32.const 2
+    i32.shr_u
+    local.set $2
+    local.get $0
+    local.get $1
+    i32.add
+    i32.const 8
+    i32.sub
+    i64.load
+    local.set $3
+    i32.const 0
+    local.set $1
+    loop $for-loop|0
+     local.get $1
+     local.get $2
+     i32.lt_u
+     if
+      local.get $3
+      i64.const 1
+      local.get $1
+      i64.extend_i32_u
+      i64.shl
+      i64.and
+      i64.const 0
+      i64.ne
+      if
+       local.get $0
+       local.get $1
+       i32.const 2
+       i32.shl
+       i32.add
+       i32.load
+       call $~lib/rt/itcms/__visit
+      end
+      local.get $1
+      i32.const 1
+      i32.add
+      local.set $1
+      br $for-loop|0
+     end
+    end
+    return
+   end
+   local.get $0
+   i32.load offset=4
+   call $~lib/rt/itcms/__visit
+   return
+  end
+  unreachable
+ )
+ (func $~start
+  memory.size
+  i32.const 16
+  i32.shl
+  i32.const 33292
+  i32.sub
+  i32.const 1
+  i32.shr_u
+  global.set $~lib/rt/itcms/threshold
+  i32.const 148
+  i32.const 144
+  i32.store
+  i32.const 152
+  i32.const 144
+  i32.store
+  i32.const 144
+  global.set $~lib/rt/itcms/pinSpace
+  i32.const 180
+  i32.const 176
+  i32.store
+  i32.const 184
+  i32.const 176
+  i32.store
+  i32.const 176
+  global.set $~lib/rt/itcms/toSpace
+  i32.const 324
+  i32.const 320
+  i32.store
+  i32.const 328
+  i32.const 320
+  i32.store
+  i32.const 320
+  global.set $~lib/rt/itcms/fromSpace
+  call $closure-tmp-function/foo
+  i32.const 6
+  i32.ne
+  if
+   i32.const 0
+   i32.const 432
+   i32.const 12
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+)

--- a/tests/frontend/compiler/closure-tmp-function.opt.wat
+++ b/tests/frontend/compiler/closure-tmp-function.opt.wat
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-tmp-function.ts
+++ b/tests/frontend/compiler/closure-tmp-function.ts
@@ -1,0 +1,12 @@
+export function getFunction(): () => i32 {
+  let aaa = 5;
+  return (): i32 => {
+    return aaa + 1;
+  };
+}
+
+export function foo(): i32 {
+  return getFunction()();
+}
+
+assert(foo() == 6);

--- a/tests/frontend/compiler/closure-tmp-function.wat
+++ b/tests/frontend/compiler/closure-tmp-function.wat
@@ -1,0 +1,3464 @@
+(module
+ (type $0 (func (param i32) (result i32)))
+ (type $1 (func (param i32 i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func (param i32 i32 i32)))
+ (type $4 (func (result i32)))
+ (type $5 (func (param i32 i32) (result i32)))
+ (type $6 (func))
+ (type $7 (func (param i32 i32 i32 i32)))
+ (type $8 (func (param i32 i32 i32) (result i32)))
+ (type $9 (func (param i32 i32 i64) (result i32)))
+ (type $10 (func (param i32 i64) (result i32)))
+ (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
+ (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+ (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
+ (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
+ (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
+ (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
+ (global $~lib/shared/runtime/Runtime.Radical i32 (i32.const 1))
+ (global $~lib/shared/runtime/Runtime.Incremental i32 (i32.const 2))
+ (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/visitCount (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/pinSpace (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/iter (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/toSpace (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
+ (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
+ (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~argumentsLength (mut i32) (i32.const 0))
+ (global $~lib/rt/__rtti_base i32 (i32.const 496))
+ (global $~lib/memory/__data_end i32 (i32.const 524))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33292))
+ (global $~lib/memory/__heap_base i32 (i32.const 33292))
+ (memory $0 1)
+ (data $0 (i32.const 12) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
+ (data $1 (i32.const 76) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $2 (i32.const 144) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $3 (i32.const 176) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $4 (i32.const 204) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00\00\00\00\00\00\00\00\00")
+ (data $5 (i32.const 268) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00\00\00\00\00\00\00\00\00")
+ (data $6 (i32.const 320) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $7 (i32.const 348) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $8 (i32.const 412) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00.\00\00\00c\00l\00o\00s\00u\00r\00e\00-\00t\00m\00p\00-\00f\00u\00n\00c\00t\00i\00o\00n\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $9 (i32.const 496) "\06\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (table $0 2 2 funcref)
+ (elem $0 (i32.const 1) $closure-tmp-function/getFunction~anonymous|0)
+ (export "getFunction" (func $closure-tmp-function/getFunction))
+ (export "foo" (func $closure-tmp-function/foo))
+ (export "memory" (memory $0))
+ (start $~start)
+ (func $~lib/tuple/SmallTuple#__set<i32> (param $this i32) (param $offset i32) (param $value i32)
+  (local $elementPtr i32)
+  (local.set $elementPtr
+   (i32.add
+    (local.get $this)
+    (local.get $offset)
+   )
+  )
+  (i32.store
+   (local.get $elementPtr)
+   (local.get $value)
+  )
+  (drop
+   (i32.const 0)
+  )
+ )
+ (func $~lib/tuple/SmallTuple#__get<i32> (param $this i32) (param $offset i32) (result i32)
+  (local $elementPtr i32)
+  (local.set $elementPtr
+   (i32.add
+    (local.get $this)
+    (local.get $offset)
+   )
+  )
+  (return
+   (i32.load
+    (local.get $elementPtr)
+   )
+  )
+ )
+ (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
+  (i32.store offset=4
+   (local.get $this)
+   (local.get $nextWithColor)
+  )
+ )
+ (func $~lib/rt/itcms/Object#set:prev (param $this i32) (param $prev i32)
+  (i32.store offset=8
+   (local.get $this)
+   (local.get $prev)
+  )
+ )
+ (func $~lib/rt/itcms/initLazy (param $space i32) (result i32)
+  (call $~lib/rt/itcms/Object#set:nextWithColor
+   (local.get $space)
+   (local.get $space)
+  )
+  (call $~lib/rt/itcms/Object#set:prev
+   (local.get $space)
+   (local.get $space)
+  )
+  (return
+   (local.get $space)
+  )
+ )
+ (func $~lib/rt/itcms/Object#get:nextWithColor (param $this i32) (result i32)
+  (i32.load offset=4
+   (local.get $this)
+  )
+ )
+ (func $~lib/rt/itcms/Object#get:next (param $this i32) (result i32)
+  (return
+   (i32.and
+    (call $~lib/rt/itcms/Object#get:nextWithColor
+     (local.get $this)
+    )
+    (i32.xor
+     (i32.const 3)
+     (i32.const -1)
+    )
+   )
+  )
+ )
+ (func $~lib/rt/itcms/Object#get:color (param $this i32) (result i32)
+  (return
+   (i32.and
+    (call $~lib/rt/itcms/Object#get:nextWithColor
+     (local.get $this)
+    )
+    (i32.const 3)
+   )
+  )
+ )
+ (func $~lib/rt/itcms/visitRoots (param $cookie i32)
+  (local $pn i32)
+  (local $iter i32)
+  (call $~lib/rt/__visit_globals
+   (local.get $cookie)
+  )
+  (local.set $pn
+   (global.get $~lib/rt/itcms/pinSpace)
+  )
+  (local.set $iter
+   (call $~lib/rt/itcms/Object#get:next
+    (local.get $pn)
+   )
+  )
+  (block $while-break|0
+   (loop $while-continue|0
+    (if
+     (i32.ne
+      (local.get $iter)
+      (local.get $pn)
+     )
+     (then
+      (drop
+       (i32.const 1)
+      )
+      (if
+       (i32.eqz
+        (i32.eq
+         (call $~lib/rt/itcms/Object#get:color
+          (local.get $iter)
+         )
+         (i32.const 3)
+        )
+       )
+       (then
+        (call $~lib/builtins/abort
+         (i32.const 0)
+         (i32.const 96)
+         (i32.const 159)
+         (i32.const 16)
+        )
+        (unreachable)
+       )
+      )
+      (call $~lib/rt/__visit_members
+       (i32.add
+        (local.get $iter)
+        (i32.const 20)
+       )
+       (local.get $cookie)
+      )
+      (local.set $iter
+       (call $~lib/rt/itcms/Object#get:next
+        (local.get $iter)
+       )
+      )
+      (br $while-continue|0)
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/itcms/Object#set:color (param $this i32) (param $color i32)
+  (call $~lib/rt/itcms/Object#set:nextWithColor
+   (local.get $this)
+   (i32.or
+    (i32.and
+     (call $~lib/rt/itcms/Object#get:nextWithColor
+      (local.get $this)
+     )
+     (i32.xor
+      (i32.const 3)
+      (i32.const -1)
+     )
+    )
+    (local.get $color)
+   )
+  )
+ )
+ (func $~lib/rt/itcms/Object#get:prev (param $this i32) (result i32)
+  (i32.load offset=8
+   (local.get $this)
+  )
+ )
+ (func $~lib/rt/itcms/Object#set:next (param $this i32) (param $obj i32)
+  (call $~lib/rt/itcms/Object#set:nextWithColor
+   (local.get $this)
+   (i32.or
+    (local.get $obj)
+    (i32.and
+     (call $~lib/rt/itcms/Object#get:nextWithColor
+      (local.get $this)
+     )
+     (i32.const 3)
+    )
+   )
+  )
+ )
+ (func $~lib/rt/itcms/Object#unlink (param $this i32)
+  (local $next i32)
+  (local $prev i32)
+  (local.set $next
+   (call $~lib/rt/itcms/Object#get:next
+    (local.get $this)
+   )
+  )
+  (if
+   (i32.eq
+    (local.get $next)
+    (i32.const 0)
+   )
+   (then
+    (drop
+     (i32.const 1)
+    )
+    (if
+     (i32.eqz
+      (if (result i32)
+       (i32.eq
+        (call $~lib/rt/itcms/Object#get:prev
+         (local.get $this)
+        )
+        (i32.const 0)
+       )
+       (then
+        (i32.lt_u
+         (local.get $this)
+         (global.get $~lib/memory/__heap_base)
+        )
+       )
+       (else
+        (i32.const 0)
+       )
+      )
+     )
+     (then
+      (call $~lib/builtins/abort
+       (i32.const 0)
+       (i32.const 96)
+       (i32.const 127)
+       (i32.const 18)
+      )
+      (unreachable)
+     )
+    )
+    (return)
+   )
+  )
+  (local.set $prev
+   (call $~lib/rt/itcms/Object#get:prev
+    (local.get $this)
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (local.get $prev)
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 96)
+     (i32.const 131)
+     (i32.const 16)
+    )
+    (unreachable)
+   )
+  )
+  (call $~lib/rt/itcms/Object#set:prev
+   (local.get $next)
+   (local.get $prev)
+  )
+  (call $~lib/rt/itcms/Object#set:next
+   (local.get $prev)
+   (local.get $next)
+  )
+ )
+ (func $~lib/rt/itcms/Object#get:rtId (param $this i32) (result i32)
+  (i32.load offset=12
+   (local.get $this)
+  )
+ )
+ (func $~lib/shared/typeinfo/Typeinfo#get:flags (param $this i32) (result i32)
+  (i32.load
+   (local.get $this)
+  )
+ )
+ (func $~lib/rt/__typeinfo (param $id i32) (result i32)
+  (local $ptr i32)
+  (local.set $ptr
+   (global.get $~lib/rt/__rtti_base)
+  )
+  (if
+   (i32.gt_u
+    (local.get $id)
+    (i32.load
+     (local.get $ptr)
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 224)
+     (i32.const 288)
+     (i32.const 22)
+     (i32.const 28)
+    )
+    (unreachable)
+   )
+  )
+  (return
+   (call $~lib/shared/typeinfo/Typeinfo#get:flags
+    (i32.add
+     (i32.add
+      (local.get $ptr)
+      (i32.const 4)
+     )
+     (i32.mul
+      (local.get $id)
+      (i32.const 4)
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/itcms/Object#get:isPointerfree (param $this i32) (result i32)
+  (local $rtId i32)
+  (local.set $rtId
+   (call $~lib/rt/itcms/Object#get:rtId
+    (local.get $this)
+   )
+  )
+  (return
+   (if (result i32)
+    (i32.le_u
+     (local.get $rtId)
+     (i32.const 2)
+    )
+    (then
+     (i32.const 1)
+    )
+    (else
+     (i32.ne
+      (i32.and
+       (call $~lib/rt/__typeinfo
+        (local.get $rtId)
+       )
+       (i32.const 32)
+      )
+      (i32.const 0)
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/itcms/Object#linkTo (param $this i32) (param $list i32) (param $withColor i32)
+  (local $prev i32)
+  (local.set $prev
+   (call $~lib/rt/itcms/Object#get:prev
+    (local.get $list)
+   )
+  )
+  (call $~lib/rt/itcms/Object#set:nextWithColor
+   (local.get $this)
+   (i32.or
+    (local.get $list)
+    (local.get $withColor)
+   )
+  )
+  (call $~lib/rt/itcms/Object#set:prev
+   (local.get $this)
+   (local.get $prev)
+  )
+  (call $~lib/rt/itcms/Object#set:next
+   (local.get $prev)
+   (local.get $this)
+  )
+  (call $~lib/rt/itcms/Object#set:prev
+   (local.get $list)
+   (local.get $this)
+  )
+ )
+ (func $~lib/rt/itcms/Object#makeGray (param $this i32)
+  (local $1 i32)
+  (if
+   (i32.eq
+    (local.get $this)
+    (global.get $~lib/rt/itcms/iter)
+   )
+   (then
+    (global.set $~lib/rt/itcms/iter
+     (if (result i32)
+      (i32.eqz
+       (local.tee $1
+        (call $~lib/rt/itcms/Object#get:prev
+         (local.get $this)
+        )
+       )
+      )
+      (then
+       (call $~lib/builtins/abort
+        (i32.const 0)
+        (i32.const 96)
+        (i32.const 147)
+        (i32.const 30)
+       )
+       (unreachable)
+      )
+      (else
+       (local.get $1)
+      )
+     )
+    )
+   )
+  )
+  (call $~lib/rt/itcms/Object#unlink
+   (local.get $this)
+  )
+  (call $~lib/rt/itcms/Object#linkTo
+   (local.get $this)
+   (global.get $~lib/rt/itcms/toSpace)
+   (if (result i32)
+    (call $~lib/rt/itcms/Object#get:isPointerfree
+     (local.get $this)
+    )
+    (then
+     (i32.eqz
+      (global.get $~lib/rt/itcms/white)
+     )
+    )
+    (else
+     (i32.const 2)
+    )
+   )
+  )
+ )
+ (func $~lib/rt/itcms/__visit (param $ptr i32) (param $cookie i32)
+  (local $obj i32)
+  (if
+   (i32.eqz
+    (local.get $ptr)
+   )
+   (then
+    (return)
+   )
+  )
+  (local.set $obj
+   (i32.sub
+    (local.get $ptr)
+    (i32.const 20)
+   )
+  )
+  (if
+   (i32.eq
+    (call $~lib/rt/itcms/Object#get:color
+     (local.get $obj)
+    )
+    (global.get $~lib/rt/itcms/white)
+   )
+   (then
+    (call $~lib/rt/itcms/Object#makeGray
+     (local.get $obj)
+    )
+    (global.set $~lib/rt/itcms/visitCount
+     (i32.add
+      (global.get $~lib/rt/itcms/visitCount)
+      (i32.const 1)
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/itcms/visitStack (param $cookie i32)
+  (local $ptr i32)
+  (local.set $ptr
+   (global.get $~lib/memory/__stack_pointer)
+  )
+  (block $while-break|0
+   (loop $while-continue|0
+    (if
+     (i32.lt_u
+      (local.get $ptr)
+      (global.get $~lib/memory/__heap_base)
+     )
+     (then
+      (call $~lib/rt/itcms/__visit
+       (i32.load
+        (local.get $ptr)
+       )
+       (local.get $cookie)
+      )
+      (local.set $ptr
+       (i32.add
+        (local.get $ptr)
+        (i32.const 4)
+       )
+      )
+      (br $while-continue|0)
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/common/BLOCK#get:mmInfo (param $this i32) (result i32)
+  (i32.load
+   (local.get $this)
+  )
+ )
+ (func $~lib/rt/itcms/Object#get:size (param $this i32) (result i32)
+  (return
+   (i32.add
+    (i32.const 4)
+    (i32.and
+     (call $~lib/rt/common/BLOCK#get:mmInfo
+      (local.get $this)
+     )
+     (i32.xor
+      (i32.const 3)
+      (i32.const -1)
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/tlsf/Root#set:flMap (param $this i32) (param $flMap i32)
+  (i32.store
+   (local.get $this)
+   (local.get $flMap)
+  )
+ )
+ (func $~lib/rt/tlsf/SETTAIL (param $root i32) (param $tail i32)
+  (i32.store offset=1568
+   (local.get $root)
+   (local.get $tail)
+  )
+ )
+ (func $~lib/rt/tlsf/SETSL (param $root i32) (param $fl i32) (param $slMap i32)
+  (i32.store offset=4
+   (i32.add
+    (local.get $root)
+    (i32.shl
+     (local.get $fl)
+     (i32.const 2)
+    )
+   )
+   (local.get $slMap)
+  )
+ )
+ (func $~lib/rt/tlsf/SETHEAD (param $root i32) (param $fl i32) (param $sl i32) (param $head i32)
+  (i32.store offset=96
+   (i32.add
+    (local.get $root)
+    (i32.shl
+     (i32.add
+      (i32.shl
+       (local.get $fl)
+       (i32.const 4)
+      )
+      (local.get $sl)
+     )
+     (i32.const 2)
+    )
+   )
+   (local.get $head)
+  )
+ )
+ (func $~lib/rt/tlsf/GETTAIL (param $root i32) (result i32)
+  (return
+   (i32.load offset=1568
+    (local.get $root)
+   )
+  )
+ )
+ (func $~lib/rt/common/BLOCK#set:mmInfo (param $this i32) (param $mmInfo i32)
+  (i32.store
+   (local.get $this)
+   (local.get $mmInfo)
+  )
+ )
+ (func $~lib/rt/tlsf/Block#set:prev (param $this i32) (param $prev i32)
+  (i32.store offset=4
+   (local.get $this)
+   (local.get $prev)
+  )
+ )
+ (func $~lib/rt/tlsf/Block#set:next (param $this i32) (param $next i32)
+  (i32.store offset=8
+   (local.get $this)
+   (local.get $next)
+  )
+ )
+ (func $~lib/rt/tlsf/GETRIGHT (param $block i32) (result i32)
+  (return
+   (i32.add
+    (i32.add
+     (local.get $block)
+     (i32.const 4)
+    )
+    (i32.and
+     (call $~lib/rt/common/BLOCK#get:mmInfo
+      (local.get $block)
+     )
+     (i32.xor
+      (i32.const 3)
+      (i32.const -1)
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/tlsf/Block#get:prev (param $this i32) (result i32)
+  (i32.load offset=4
+   (local.get $this)
+  )
+ )
+ (func $~lib/rt/tlsf/Block#get:next (param $this i32) (result i32)
+  (i32.load offset=8
+   (local.get $this)
+  )
+ )
+ (func $~lib/rt/tlsf/GETHEAD (param $root i32) (param $fl i32) (param $sl i32) (result i32)
+  (return
+   (i32.load offset=96
+    (i32.add
+     (local.get $root)
+     (i32.shl
+      (i32.add
+       (i32.shl
+        (local.get $fl)
+        (i32.const 4)
+       )
+       (local.get $sl)
+      )
+      (i32.const 2)
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/tlsf/GETSL (param $root i32) (param $fl i32) (result i32)
+  (return
+   (i32.load offset=4
+    (i32.add
+     (local.get $root)
+     (i32.shl
+      (local.get $fl)
+      (i32.const 2)
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/tlsf/Root#get:flMap (param $this i32) (result i32)
+  (i32.load
+   (local.get $this)
+  )
+ )
+ (func $~lib/rt/tlsf/removeBlock (param $root i32) (param $block i32)
+  (local $blockInfo i32)
+  (local $size i32)
+  (local $fl i32)
+  (local $sl i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $boundedSize i32)
+  (local $prev i32)
+  (local $next i32)
+  (local $slMap i32)
+  (local.set $blockInfo
+   (call $~lib/rt/common/BLOCK#get:mmInfo
+    (local.get $block)
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (i32.and
+     (local.get $blockInfo)
+     (i32.const 1)
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 368)
+     (i32.const 245)
+     (i32.const 14)
+    )
+    (unreachable)
+   )
+  )
+  (local.set $size
+   (i32.and
+    (local.get $blockInfo)
+    (i32.xor
+     (i32.const 3)
+     (i32.const -1)
+    )
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (i32.ge_u
+     (local.get $size)
+     (i32.const 12)
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 368)
+     (i32.const 247)
+     (i32.const 14)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $size)
+    (i32.const 256)
+   )
+   (then
+    (local.set $fl
+     (i32.const 0)
+    )
+    (local.set $sl
+     (i32.shr_u
+      (local.get $size)
+      (i32.const 4)
+     )
+    )
+   )
+   (else
+    (local.set $boundedSize
+     (select
+      (local.tee $6
+       (local.get $size)
+      )
+      (local.tee $7
+       (i32.const 1073741820)
+      )
+      (i32.lt_u
+       (local.get $6)
+       (local.get $7)
+      )
+     )
+    )
+    (local.set $fl
+     (i32.sub
+      (i32.const 31)
+      (i32.clz
+       (local.get $boundedSize)
+      )
+     )
+    )
+    (local.set $sl
+     (i32.xor
+      (i32.shr_u
+       (local.get $boundedSize)
+       (i32.sub
+        (local.get $fl)
+        (i32.const 4)
+       )
+      )
+      (i32.shl
+       (i32.const 1)
+       (i32.const 4)
+      )
+     )
+    )
+    (local.set $fl
+     (i32.sub
+      (local.get $fl)
+      (i32.sub
+       (i32.const 8)
+       (i32.const 1)
+      )
+     )
+    )
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (if (result i32)
+     (i32.lt_u
+      (local.get $fl)
+      (i32.const 23)
+     )
+     (then
+      (i32.lt_u
+       (local.get $sl)
+       (i32.const 16)
+      )
+     )
+     (else
+      (i32.const 0)
+     )
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 368)
+     (i32.const 261)
+     (i32.const 14)
+    )
+    (unreachable)
+   )
+  )
+  (local.set $prev
+   (call $~lib/rt/tlsf/Block#get:prev
+    (local.get $block)
+   )
+  )
+  (local.set $next
+   (call $~lib/rt/tlsf/Block#get:next
+    (local.get $block)
+   )
+  )
+  (if
+   (local.get $prev)
+   (then
+    (call $~lib/rt/tlsf/Block#set:next
+     (local.get $prev)
+     (local.get $next)
+    )
+   )
+  )
+  (if
+   (local.get $next)
+   (then
+    (call $~lib/rt/tlsf/Block#set:prev
+     (local.get $next)
+     (local.get $prev)
+    )
+   )
+  )
+  (if
+   (i32.eq
+    (local.get $block)
+    (call $~lib/rt/tlsf/GETHEAD
+     (local.get $root)
+     (local.get $fl)
+     (local.get $sl)
+    )
+   )
+   (then
+    (call $~lib/rt/tlsf/SETHEAD
+     (local.get $root)
+     (local.get $fl)
+     (local.get $sl)
+     (local.get $next)
+    )
+    (if
+     (i32.eqz
+      (local.get $next)
+     )
+     (then
+      (local.set $slMap
+       (call $~lib/rt/tlsf/GETSL
+        (local.get $root)
+        (local.get $fl)
+       )
+      )
+      (call $~lib/rt/tlsf/SETSL
+       (local.get $root)
+       (local.get $fl)
+       (local.tee $slMap
+        (i32.and
+         (local.get $slMap)
+         (i32.xor
+          (i32.shl
+           (i32.const 1)
+           (local.get $sl)
+          )
+          (i32.const -1)
+         )
+        )
+       )
+      )
+      (if
+       (i32.eqz
+        (local.get $slMap)
+       )
+       (then
+        (call $~lib/rt/tlsf/Root#set:flMap
+         (local.get $root)
+         (i32.and
+          (call $~lib/rt/tlsf/Root#get:flMap
+           (local.get $root)
+          )
+          (i32.xor
+           (i32.shl
+            (i32.const 1)
+            (local.get $fl)
+           )
+           (i32.const -1)
+          )
+         )
+        )
+       )
+      )
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/tlsf/GETFREELEFT (param $block i32) (result i32)
+  (return
+   (i32.load
+    (i32.sub
+     (local.get $block)
+     (i32.const 4)
+    )
+   )
+  )
+ )
+ (func $~lib/rt/tlsf/insertBlock (param $root i32) (param $block i32)
+  (local $blockInfo i32)
+  (local $right i32)
+  (local $rightInfo i32)
+  (local $left i32)
+  (local $leftInfo i32)
+  (local $size i32)
+  (local $fl i32)
+  (local $sl i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $boundedSize i32)
+  (local $head i32)
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (local.get $block)
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 368)
+     (i32.const 178)
+     (i32.const 14)
+    )
+    (unreachable)
+   )
+  )
+  (local.set $blockInfo
+   (call $~lib/rt/common/BLOCK#get:mmInfo
+    (local.get $block)
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (i32.and
+     (local.get $blockInfo)
+     (i32.const 1)
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 368)
+     (i32.const 180)
+     (i32.const 14)
+    )
+    (unreachable)
+   )
+  )
+  (local.set $right
+   (call $~lib/rt/tlsf/GETRIGHT
+    (local.get $block)
+   )
+  )
+  (local.set $rightInfo
+   (call $~lib/rt/common/BLOCK#get:mmInfo
+    (local.get $right)
+   )
+  )
+  (if
+   (i32.and
+    (local.get $rightInfo)
+    (i32.const 1)
+   )
+   (then
+    (call $~lib/rt/tlsf/removeBlock
+     (local.get $root)
+     (local.get $right)
+    )
+    (call $~lib/rt/common/BLOCK#set:mmInfo
+     (local.get $block)
+     (local.tee $blockInfo
+      (i32.add
+       (i32.add
+        (local.get $blockInfo)
+        (i32.const 4)
+       )
+       (i32.and
+        (local.get $rightInfo)
+        (i32.xor
+         (i32.const 3)
+         (i32.const -1)
+        )
+       )
+      )
+     )
+    )
+    (local.set $right
+     (call $~lib/rt/tlsf/GETRIGHT
+      (local.get $block)
+     )
+    )
+    (local.set $rightInfo
+     (call $~lib/rt/common/BLOCK#get:mmInfo
+      (local.get $right)
+     )
+    )
+   )
+  )
+  (if
+   (i32.and
+    (local.get $blockInfo)
+    (i32.const 2)
+   )
+   (then
+    (local.set $left
+     (call $~lib/rt/tlsf/GETFREELEFT
+      (local.get $block)
+     )
+    )
+    (local.set $leftInfo
+     (call $~lib/rt/common/BLOCK#get:mmInfo
+      (local.get $left)
+     )
+    )
+    (drop
+     (i32.const 1)
+    )
+    (if
+     (i32.eqz
+      (i32.and
+       (local.get $leftInfo)
+       (i32.const 1)
+      )
+     )
+     (then
+      (call $~lib/builtins/abort
+       (i32.const 0)
+       (i32.const 368)
+       (i32.const 198)
+       (i32.const 16)
+      )
+      (unreachable)
+     )
+    )
+    (call $~lib/rt/tlsf/removeBlock
+     (local.get $root)
+     (local.get $left)
+    )
+    (local.set $block
+     (local.get $left)
+    )
+    (call $~lib/rt/common/BLOCK#set:mmInfo
+     (local.get $block)
+     (local.tee $blockInfo
+      (i32.add
+       (i32.add
+        (local.get $leftInfo)
+        (i32.const 4)
+       )
+       (i32.and
+        (local.get $blockInfo)
+        (i32.xor
+         (i32.const 3)
+         (i32.const -1)
+        )
+       )
+      )
+     )
+    )
+   )
+  )
+  (call $~lib/rt/common/BLOCK#set:mmInfo
+   (local.get $right)
+   (i32.or
+    (local.get $rightInfo)
+    (i32.const 2)
+   )
+  )
+  (local.set $size
+   (i32.and
+    (local.get $blockInfo)
+    (i32.xor
+     (i32.const 3)
+     (i32.const -1)
+    )
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (i32.ge_u
+     (local.get $size)
+     (i32.const 12)
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 368)
+     (i32.const 210)
+     (i32.const 14)
+    )
+    (unreachable)
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (i32.add
+      (i32.add
+       (local.get $block)
+       (i32.const 4)
+      )
+      (local.get $size)
+     )
+     (local.get $right)
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 368)
+     (i32.const 211)
+     (i32.const 14)
+    )
+    (unreachable)
+   )
+  )
+  (i32.store
+   (i32.sub
+    (local.get $right)
+    (i32.const 4)
+   )
+   (local.get $block)
+  )
+  (if
+   (i32.lt_u
+    (local.get $size)
+    (i32.const 256)
+   )
+   (then
+    (local.set $fl
+     (i32.const 0)
+    )
+    (local.set $sl
+     (i32.shr_u
+      (local.get $size)
+      (i32.const 4)
+     )
+    )
+   )
+   (else
+    (local.set $boundedSize
+     (select
+      (local.tee $10
+       (local.get $size)
+      )
+      (local.tee $11
+       (i32.const 1073741820)
+      )
+      (i32.lt_u
+       (local.get $10)
+       (local.get $11)
+      )
+     )
+    )
+    (local.set $fl
+     (i32.sub
+      (i32.const 31)
+      (i32.clz
+       (local.get $boundedSize)
+      )
+     )
+    )
+    (local.set $sl
+     (i32.xor
+      (i32.shr_u
+       (local.get $boundedSize)
+       (i32.sub
+        (local.get $fl)
+        (i32.const 4)
+       )
+      )
+      (i32.shl
+       (i32.const 1)
+       (i32.const 4)
+      )
+     )
+    )
+    (local.set $fl
+     (i32.sub
+      (local.get $fl)
+      (i32.sub
+       (i32.const 8)
+       (i32.const 1)
+      )
+     )
+    )
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (if (result i32)
+     (i32.lt_u
+      (local.get $fl)
+      (i32.const 23)
+     )
+     (then
+      (i32.lt_u
+       (local.get $sl)
+       (i32.const 16)
+      )
+     )
+     (else
+      (i32.const 0)
+     )
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 368)
+     (i32.const 228)
+     (i32.const 14)
+    )
+    (unreachable)
+   )
+  )
+  (local.set $head
+   (call $~lib/rt/tlsf/GETHEAD
+    (local.get $root)
+    (local.get $fl)
+    (local.get $sl)
+   )
+  )
+  (call $~lib/rt/tlsf/Block#set:prev
+   (local.get $block)
+   (i32.const 0)
+  )
+  (call $~lib/rt/tlsf/Block#set:next
+   (local.get $block)
+   (local.get $head)
+  )
+  (if
+   (local.get $head)
+   (then
+    (call $~lib/rt/tlsf/Block#set:prev
+     (local.get $head)
+     (local.get $block)
+    )
+   )
+  )
+  (call $~lib/rt/tlsf/SETHEAD
+   (local.get $root)
+   (local.get $fl)
+   (local.get $sl)
+   (local.get $block)
+  )
+  (call $~lib/rt/tlsf/Root#set:flMap
+   (local.get $root)
+   (i32.or
+    (call $~lib/rt/tlsf/Root#get:flMap
+     (local.get $root)
+    )
+    (i32.shl
+     (i32.const 1)
+     (local.get $fl)
+    )
+   )
+  )
+  (call $~lib/rt/tlsf/SETSL
+   (local.get $root)
+   (local.get $fl)
+   (i32.or
+    (call $~lib/rt/tlsf/GETSL
+     (local.get $root)
+     (local.get $fl)
+    )
+    (i32.shl
+     (i32.const 1)
+     (local.get $sl)
+    )
+   )
+  )
+ )
+ (func $~lib/rt/tlsf/addMemory (param $root i32) (param $start i32) (param $endU64 i64) (result i32)
+  (local $end i32)
+  (local $tail i32)
+  (local $tailInfo i32)
+  (local $size i32)
+  (local $leftSize i32)
+  (local $left i32)
+  (local.set $end
+   (i32.wrap_i64
+    (local.get $endU64)
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (i64.le_u
+     (i64.extend_i32_u
+      (local.get $start)
+     )
+     (local.get $endU64)
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 368)
+     (i32.const 357)
+     (i32.const 14)
+    )
+    (unreachable)
+   )
+  )
+  (local.set $start
+   (i32.sub
+    (i32.and
+     (i32.add
+      (i32.add
+       (local.get $start)
+       (i32.const 4)
+      )
+      (i32.const 15)
+     )
+     (i32.xor
+      (i32.const 15)
+      (i32.const -1)
+     )
+    )
+    (i32.const 4)
+   )
+  )
+  (local.set $end
+   (i32.and
+    (local.get $end)
+    (i32.xor
+     (i32.const 15)
+     (i32.const -1)
+    )
+   )
+  )
+  (local.set $tail
+   (call $~lib/rt/tlsf/GETTAIL
+    (local.get $root)
+   )
+  )
+  (local.set $tailInfo
+   (i32.const 0)
+  )
+  (if
+   (local.get $tail)
+   (then
+    (drop
+     (i32.const 1)
+    )
+    (if
+     (i32.eqz
+      (i32.ge_u
+       (local.get $start)
+       (i32.add
+        (local.get $tail)
+        (i32.const 4)
+       )
+      )
+     )
+     (then
+      (call $~lib/builtins/abort
+       (i32.const 0)
+       (i32.const 368)
+       (i32.const 365)
+       (i32.const 16)
+      )
+      (unreachable)
+     )
+    )
+    (if
+     (i32.eq
+      (i32.sub
+       (local.get $start)
+       (i32.const 16)
+      )
+      (local.get $tail)
+     )
+     (then
+      (local.set $start
+       (i32.sub
+        (local.get $start)
+        (i32.const 16)
+       )
+      )
+      (local.set $tailInfo
+       (call $~lib/rt/common/BLOCK#get:mmInfo
+        (local.get $tail)
+       )
+      )
+     )
+     (else
+      (nop)
+     )
+    )
+   )
+   (else
+    (drop
+     (i32.const 1)
+    )
+    (if
+     (i32.eqz
+      (i32.ge_u
+       (local.get $start)
+       (i32.add
+        (local.get $root)
+        (i32.const 1572)
+       )
+      )
+     )
+     (then
+      (call $~lib/builtins/abort
+       (i32.const 0)
+       (i32.const 368)
+       (i32.const 378)
+       (i32.const 5)
+      )
+      (unreachable)
+     )
+    )
+   )
+  )
+  (local.set $size
+   (i32.sub
+    (local.get $end)
+    (local.get $start)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $size)
+    (i32.add
+     (i32.add
+      (i32.const 4)
+      (i32.const 12)
+     )
+     (i32.const 4)
+    )
+   )
+   (then
+    (return
+     (i32.const 0)
+    )
+   )
+  )
+  (local.set $leftSize
+   (i32.sub
+    (local.get $size)
+    (i32.mul
+     (i32.const 2)
+     (i32.const 4)
+    )
+   )
+  )
+  (local.set $left
+   (local.get $start)
+  )
+  (call $~lib/rt/common/BLOCK#set:mmInfo
+   (local.get $left)
+   (i32.or
+    (i32.or
+     (local.get $leftSize)
+     (i32.const 1)
+    )
+    (i32.and
+     (local.get $tailInfo)
+     (i32.const 2)
+    )
+   )
+  )
+  (call $~lib/rt/tlsf/Block#set:prev
+   (local.get $left)
+   (i32.const 0)
+  )
+  (call $~lib/rt/tlsf/Block#set:next
+   (local.get $left)
+   (i32.const 0)
+  )
+  (local.set $tail
+   (i32.add
+    (i32.add
+     (local.get $start)
+     (i32.const 4)
+    )
+    (local.get $leftSize)
+   )
+  )
+  (call $~lib/rt/common/BLOCK#set:mmInfo
+   (local.get $tail)
+   (i32.or
+    (i32.const 0)
+    (i32.const 2)
+   )
+  )
+  (call $~lib/rt/tlsf/SETTAIL
+   (local.get $root)
+   (local.get $tail)
+  )
+  (call $~lib/rt/tlsf/insertBlock
+   (local.get $root)
+   (local.get $left)
+  )
+  (return
+   (i32.const 1)
+  )
+ )
+ (func $~lib/rt/tlsf/initialize
+  (local $rootOffset i32)
+  (local $pagesBefore i32)
+  (local $pagesNeeded i32)
+  (local $root i32)
+  (local $fl i32)
+  (local $sl i32)
+  (local $memStart i32)
+  (local.set $rootOffset
+   (i32.and
+    (i32.add
+     (global.get $~lib/memory/__heap_base)
+     (i32.const 15)
+    )
+    (i32.xor
+     (i32.const 15)
+     (i32.const -1)
+    )
+   )
+  )
+  (local.set $pagesBefore
+   (memory.size)
+  )
+  (local.set $pagesNeeded
+   (i32.shr_u
+    (i32.and
+     (i32.add
+      (i32.add
+       (local.get $rootOffset)
+       (i32.const 1572)
+      )
+      (i32.const 65535)
+     )
+     (i32.xor
+      (i32.const 65535)
+      (i32.const -1)
+     )
+    )
+    (i32.const 16)
+   )
+  )
+  (if
+   (if (result i32)
+    (i32.gt_s
+     (local.get $pagesNeeded)
+     (local.get $pagesBefore)
+    )
+    (then
+     (i32.lt_s
+      (memory.grow
+       (i32.sub
+        (local.get $pagesNeeded)
+        (local.get $pagesBefore)
+       )
+      )
+      (i32.const 0)
+     )
+    )
+    (else
+     (i32.const 0)
+    )
+   )
+   (then
+    (unreachable)
+   )
+  )
+  (local.set $root
+   (local.get $rootOffset)
+  )
+  (call $~lib/rt/tlsf/Root#set:flMap
+   (local.get $root)
+   (i32.const 0)
+  )
+  (call $~lib/rt/tlsf/SETTAIL
+   (local.get $root)
+   (i32.const 0)
+  )
+  (local.set $fl
+   (i32.const 0)
+  )
+  (loop $for-loop|0
+   (if
+    (i32.lt_u
+     (local.get $fl)
+     (i32.const 23)
+    )
+    (then
+     (call $~lib/rt/tlsf/SETSL
+      (local.get $root)
+      (local.get $fl)
+      (i32.const 0)
+     )
+     (local.set $sl
+      (i32.const 0)
+     )
+     (loop $for-loop|1
+      (if
+       (i32.lt_u
+        (local.get $sl)
+        (i32.const 16)
+       )
+       (then
+        (call $~lib/rt/tlsf/SETHEAD
+         (local.get $root)
+         (local.get $fl)
+         (local.get $sl)
+         (i32.const 0)
+        )
+        (local.set $sl
+         (i32.add
+          (local.get $sl)
+          (i32.const 1)
+         )
+        )
+        (br $for-loop|1)
+       )
+      )
+     )
+     (local.set $fl
+      (i32.add
+       (local.get $fl)
+       (i32.const 1)
+      )
+     )
+     (br $for-loop|0)
+    )
+   )
+  )
+  (local.set $memStart
+   (i32.add
+    (local.get $rootOffset)
+    (i32.const 1572)
+   )
+  )
+  (drop
+   (i32.const 0)
+  )
+  (drop
+   (call $~lib/rt/tlsf/addMemory
+    (local.get $root)
+    (local.get $memStart)
+    (i64.shl
+     (i64.extend_i32_s
+      (memory.size)
+     )
+     (i64.const 16)
+    )
+   )
+  )
+  (global.set $~lib/rt/tlsf/ROOT
+   (local.get $root)
+  )
+ )
+ (func $~lib/rt/tlsf/checkUsedBlock (param $ptr i32) (result i32)
+  (local $block i32)
+  (local.set $block
+   (i32.sub
+    (local.get $ptr)
+    (i32.const 4)
+   )
+  )
+  (if
+   (i32.eqz
+    (if (result i32)
+     (if (result i32)
+      (i32.ne
+       (local.get $ptr)
+       (i32.const 0)
+      )
+      (then
+       (i32.eqz
+        (i32.and
+         (local.get $ptr)
+         (i32.const 15)
+        )
+       )
+      )
+      (else
+       (i32.const 0)
+      )
+     )
+     (then
+      (i32.eqz
+       (i32.and
+        (call $~lib/rt/common/BLOCK#get:mmInfo
+         (local.get $block)
+        )
+        (i32.const 1)
+       )
+      )
+     )
+     (else
+      (i32.const 0)
+     )
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 368)
+     (i32.const 532)
+     (i32.const 3)
+    )
+    (unreachable)
+   )
+  )
+  (return
+   (local.get $block)
+  )
+ )
+ (func $~lib/rt/tlsf/freeBlock (param $root i32) (param $block i32)
+  (call $~lib/rt/common/BLOCK#set:mmInfo
+   (local.get $block)
+   (i32.or
+    (call $~lib/rt/common/BLOCK#get:mmInfo
+     (local.get $block)
+    )
+    (i32.const 1)
+   )
+  )
+  (call $~lib/rt/tlsf/insertBlock
+   (local.get $root)
+   (local.get $block)
+  )
+ )
+ (func $~lib/rt/tlsf/__free (param $ptr i32)
+  (if
+   (i32.lt_u
+    (local.get $ptr)
+    (global.get $~lib/memory/__heap_base)
+   )
+   (then
+    (return)
+   )
+  )
+  (if
+   (i32.eqz
+    (global.get $~lib/rt/tlsf/ROOT)
+   )
+   (then
+    (call $~lib/rt/tlsf/initialize)
+   )
+  )
+  (call $~lib/rt/tlsf/freeBlock
+   (global.get $~lib/rt/tlsf/ROOT)
+   (call $~lib/rt/tlsf/checkUsedBlock
+    (local.get $ptr)
+   )
+  )
+ )
+ (func $~lib/rt/itcms/free (param $obj i32)
+  (if
+   (i32.lt_u
+    (local.get $obj)
+    (global.get $~lib/memory/__heap_base)
+   )
+   (then
+    (call $~lib/rt/itcms/Object#set:nextWithColor
+     (local.get $obj)
+     (i32.const 0)
+    )
+    (call $~lib/rt/itcms/Object#set:prev
+     (local.get $obj)
+     (i32.const 0)
+    )
+   )
+   (else
+    (drop
+     (i32.const 0)
+    )
+    (global.set $~lib/rt/itcms/total
+     (i32.sub
+      (global.get $~lib/rt/itcms/total)
+      (call $~lib/rt/itcms/Object#get:size
+       (local.get $obj)
+      )
+     )
+    )
+    (drop
+     (i32.const 0)
+    )
+    (call $~lib/rt/tlsf/__free
+     (i32.add
+      (local.get $obj)
+      (i32.const 4)
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/itcms/step (result i32)
+  (local $obj i32)
+  (local $1 i32)
+  (local $black i32)
+  (local $from i32)
+  (block $break|0
+   (block $case2|0
+    (block $case1|0
+     (block $case0|0
+      (local.set $1
+       (global.get $~lib/rt/itcms/state)
+      )
+      (br_if $case0|0
+       (i32.eq
+        (local.get $1)
+        (i32.const 0)
+       )
+      )
+      (br_if $case1|0
+       (i32.eq
+        (local.get $1)
+        (i32.const 1)
+       )
+      )
+      (br_if $case2|0
+       (i32.eq
+        (local.get $1)
+        (i32.const 2)
+       )
+      )
+      (br $break|0)
+     )
+     (block
+      (global.set $~lib/rt/itcms/state
+       (i32.const 1)
+      )
+      (global.set $~lib/rt/itcms/visitCount
+       (i32.const 0)
+      )
+      (call $~lib/rt/itcms/visitRoots
+       (i32.const 0)
+      )
+      (global.set $~lib/rt/itcms/iter
+       (global.get $~lib/rt/itcms/toSpace)
+      )
+      (return
+       (i32.mul
+        (global.get $~lib/rt/itcms/visitCount)
+        (i32.const 1)
+       )
+      )
+     )
+    )
+    (block
+     (local.set $black
+      (i32.eqz
+       (global.get $~lib/rt/itcms/white)
+      )
+     )
+     (local.set $obj
+      (call $~lib/rt/itcms/Object#get:next
+       (global.get $~lib/rt/itcms/iter)
+      )
+     )
+     (block $while-break|1
+      (loop $while-continue|1
+       (if
+        (i32.ne
+         (local.get $obj)
+         (global.get $~lib/rt/itcms/toSpace)
+        )
+        (then
+         (global.set $~lib/rt/itcms/iter
+          (local.get $obj)
+         )
+         (if
+          (i32.ne
+           (call $~lib/rt/itcms/Object#get:color
+            (local.get $obj)
+           )
+           (local.get $black)
+          )
+          (then
+           (call $~lib/rt/itcms/Object#set:color
+            (local.get $obj)
+            (local.get $black)
+           )
+           (global.set $~lib/rt/itcms/visitCount
+            (i32.const 0)
+           )
+           (call $~lib/rt/__visit_members
+            (i32.add
+             (local.get $obj)
+             (i32.const 20)
+            )
+            (i32.const 0)
+           )
+           (return
+            (i32.mul
+             (global.get $~lib/rt/itcms/visitCount)
+             (i32.const 1)
+            )
+           )
+          )
+         )
+         (local.set $obj
+          (call $~lib/rt/itcms/Object#get:next
+           (local.get $obj)
+          )
+         )
+         (br $while-continue|1)
+        )
+       )
+      )
+     )
+     (global.set $~lib/rt/itcms/visitCount
+      (i32.const 0)
+     )
+     (call $~lib/rt/itcms/visitRoots
+      (i32.const 0)
+     )
+     (local.set $obj
+      (call $~lib/rt/itcms/Object#get:next
+       (global.get $~lib/rt/itcms/iter)
+      )
+     )
+     (if
+      (i32.eq
+       (local.get $obj)
+       (global.get $~lib/rt/itcms/toSpace)
+      )
+      (then
+       (call $~lib/rt/itcms/visitStack
+        (i32.const 0)
+       )
+       (local.set $obj
+        (call $~lib/rt/itcms/Object#get:next
+         (global.get $~lib/rt/itcms/iter)
+        )
+       )
+       (block $while-break|2
+        (loop $while-continue|2
+         (if
+          (i32.ne
+           (local.get $obj)
+           (global.get $~lib/rt/itcms/toSpace)
+          )
+          (then
+           (if
+            (i32.ne
+             (call $~lib/rt/itcms/Object#get:color
+              (local.get $obj)
+             )
+             (local.get $black)
+            )
+            (then
+             (call $~lib/rt/itcms/Object#set:color
+              (local.get $obj)
+              (local.get $black)
+             )
+             (call $~lib/rt/__visit_members
+              (i32.add
+               (local.get $obj)
+               (i32.const 20)
+              )
+              (i32.const 0)
+             )
+            )
+           )
+           (local.set $obj
+            (call $~lib/rt/itcms/Object#get:next
+             (local.get $obj)
+            )
+           )
+           (br $while-continue|2)
+          )
+         )
+        )
+       )
+       (local.set $from
+        (global.get $~lib/rt/itcms/fromSpace)
+       )
+       (global.set $~lib/rt/itcms/fromSpace
+        (global.get $~lib/rt/itcms/toSpace)
+       )
+       (global.set $~lib/rt/itcms/toSpace
+        (local.get $from)
+       )
+       (global.set $~lib/rt/itcms/white
+        (local.get $black)
+       )
+       (global.set $~lib/rt/itcms/iter
+        (call $~lib/rt/itcms/Object#get:next
+         (local.get $from)
+        )
+       )
+       (global.set $~lib/rt/itcms/state
+        (i32.const 2)
+       )
+      )
+     )
+     (return
+      (i32.mul
+       (global.get $~lib/rt/itcms/visitCount)
+       (i32.const 1)
+      )
+     )
+    )
+   )
+   (block
+    (local.set $obj
+     (global.get $~lib/rt/itcms/iter)
+    )
+    (if
+     (i32.ne
+      (local.get $obj)
+      (global.get $~lib/rt/itcms/toSpace)
+     )
+     (then
+      (global.set $~lib/rt/itcms/iter
+       (call $~lib/rt/itcms/Object#get:next
+        (local.get $obj)
+       )
+      )
+      (drop
+       (i32.const 1)
+      )
+      (if
+       (i32.eqz
+        (i32.eq
+         (call $~lib/rt/itcms/Object#get:color
+          (local.get $obj)
+         )
+         (i32.eqz
+          (global.get $~lib/rt/itcms/white)
+         )
+        )
+       )
+       (then
+        (call $~lib/builtins/abort
+         (i32.const 0)
+         (i32.const 96)
+         (i32.const 229)
+         (i32.const 20)
+        )
+        (unreachable)
+       )
+      )
+      (call $~lib/rt/itcms/free
+       (local.get $obj)
+      )
+      (return
+       (i32.const 10)
+      )
+     )
+    )
+    (call $~lib/rt/itcms/Object#set:nextWithColor
+     (global.get $~lib/rt/itcms/toSpace)
+     (global.get $~lib/rt/itcms/toSpace)
+    )
+    (call $~lib/rt/itcms/Object#set:prev
+     (global.get $~lib/rt/itcms/toSpace)
+     (global.get $~lib/rt/itcms/toSpace)
+    )
+    (global.set $~lib/rt/itcms/state
+     (i32.const 0)
+    )
+    (br $break|0)
+   )
+  )
+  (return
+   (i32.const 0)
+  )
+ )
+ (func $~lib/rt/itcms/interrupt
+  (local $budget i32)
+  (drop
+   (i32.const 0)
+  )
+  (local.set $budget
+   (i32.div_u
+    (i32.mul
+     (i32.const 1024)
+     (i32.const 200)
+    )
+    (i32.const 100)
+   )
+  )
+  (loop $do-loop|0
+   (local.set $budget
+    (i32.sub
+     (local.get $budget)
+     (call $~lib/rt/itcms/step)
+    )
+   )
+   (if
+    (i32.eq
+     (global.get $~lib/rt/itcms/state)
+     (i32.const 0)
+    )
+    (then
+     (drop
+      (i32.const 0)
+     )
+     (drop
+      (i32.eq
+       (i32.rem_u
+        (i32.const 200)
+        (i32.const 100)
+       )
+       (i32.const 0)
+      )
+     )
+     (global.set $~lib/rt/itcms/threshold
+      (i32.add
+       (i32.mul
+        (global.get $~lib/rt/itcms/total)
+        (i32.div_u
+         (i32.const 200)
+         (i32.const 100)
+        )
+       )
+       (i32.const 1024)
+      )
+     )
+     (return)
+    )
+   )
+   (br_if $do-loop|0
+    (i32.gt_s
+     (local.get $budget)
+     (i32.const 0)
+    )
+   )
+  )
+  (drop
+   (i32.const 0)
+  )
+  (global.set $~lib/rt/itcms/threshold
+   (i32.add
+    (global.get $~lib/rt/itcms/total)
+    (i32.mul
+     (i32.const 1024)
+     (i32.lt_u
+      (i32.sub
+       (global.get $~lib/rt/itcms/total)
+       (global.get $~lib/rt/itcms/threshold)
+      )
+      (i32.const 1024)
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/tlsf/computeSize (param $size i32) (result i32)
+  (return
+   (if (result i32)
+    (i32.le_u
+     (local.get $size)
+     (i32.const 12)
+    )
+    (then
+     (i32.const 12)
+    )
+    (else
+     (i32.sub
+      (i32.and
+       (i32.add
+        (i32.add
+         (local.get $size)
+         (i32.const 4)
+        )
+        (i32.const 15)
+       )
+       (i32.xor
+        (i32.const 15)
+        (i32.const -1)
+       )
+      )
+      (i32.const 4)
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/tlsf/prepareSize (param $size i32) (result i32)
+  (if
+   (i32.gt_u
+    (local.get $size)
+    (i32.const 1073741820)
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 32)
+     (i32.const 368)
+     (i32.const 435)
+     (i32.const 29)
+    )
+    (unreachable)
+   )
+  )
+  (return
+   (call $~lib/rt/tlsf/computeSize
+    (local.get $size)
+   )
+  )
+ )
+ (func $~lib/rt/tlsf/roundSize (param $size i32) (result i32)
+  (return
+   (if (result i32)
+    (i32.lt_u
+     (local.get $size)
+     (i32.const 536870910)
+    )
+    (then
+     (i32.sub
+      (i32.add
+       (local.get $size)
+       (i32.shl
+        (i32.const 1)
+        (i32.sub
+         (i32.const 27)
+         (i32.clz
+          (local.get $size)
+         )
+        )
+       )
+      )
+      (i32.const 1)
+     )
+    )
+    (else
+     (local.get $size)
+    )
+   )
+  )
+ )
+ (func $~lib/rt/tlsf/searchBlock (param $root i32) (param $size i32) (result i32)
+  (local $fl i32)
+  (local $sl i32)
+  (local $requestSize i32)
+  (local $slMap i32)
+  (local $head i32)
+  (local $flMap i32)
+  (if
+   (i32.lt_u
+    (local.get $size)
+    (i32.const 256)
+   )
+   (then
+    (local.set $fl
+     (i32.const 0)
+    )
+    (local.set $sl
+     (i32.shr_u
+      (local.get $size)
+      (i32.const 4)
+     )
+    )
+   )
+   (else
+    (local.set $requestSize
+     (call $~lib/rt/tlsf/roundSize
+      (local.get $size)
+     )
+    )
+    (local.set $fl
+     (i32.sub
+      (i32.sub
+       (i32.mul
+        (i32.const 4)
+        (i32.const 8)
+       )
+       (i32.const 1)
+      )
+      (i32.clz
+       (local.get $requestSize)
+      )
+     )
+    )
+    (local.set $sl
+     (i32.xor
+      (i32.shr_u
+       (local.get $requestSize)
+       (i32.sub
+        (local.get $fl)
+        (i32.const 4)
+       )
+      )
+      (i32.shl
+       (i32.const 1)
+       (i32.const 4)
+      )
+     )
+    )
+    (local.set $fl
+     (i32.sub
+      (local.get $fl)
+      (i32.sub
+       (i32.const 8)
+       (i32.const 1)
+      )
+     )
+    )
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (if (result i32)
+     (i32.lt_u
+      (local.get $fl)
+      (i32.const 23)
+     )
+     (then
+      (i32.lt_u
+       (local.get $sl)
+       (i32.const 16)
+      )
+     )
+     (else
+      (i32.const 0)
+     )
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 368)
+     (i32.const 309)
+     (i32.const 14)
+    )
+    (unreachable)
+   )
+  )
+  (local.set $slMap
+   (i32.and
+    (call $~lib/rt/tlsf/GETSL
+     (local.get $root)
+     (local.get $fl)
+    )
+    (i32.shl
+     (i32.xor
+      (i32.const 0)
+      (i32.const -1)
+     )
+     (local.get $sl)
+    )
+   )
+  )
+  (local.set $head
+   (i32.const 0)
+  )
+  (if
+   (i32.eqz
+    (local.get $slMap)
+   )
+   (then
+    (local.set $flMap
+     (i32.and
+      (call $~lib/rt/tlsf/Root#get:flMap
+       (local.get $root)
+      )
+      (i32.shl
+       (i32.xor
+        (i32.const 0)
+        (i32.const -1)
+       )
+       (i32.add
+        (local.get $fl)
+        (i32.const 1)
+       )
+      )
+     )
+    )
+    (if
+     (i32.eqz
+      (local.get $flMap)
+     )
+     (then
+      (local.set $head
+       (i32.const 0)
+      )
+     )
+     (else
+      (local.set $fl
+       (i32.ctz
+        (local.get $flMap)
+       )
+      )
+      (local.set $slMap
+       (call $~lib/rt/tlsf/GETSL
+        (local.get $root)
+        (local.get $fl)
+       )
+      )
+      (drop
+       (i32.const 1)
+      )
+      (if
+       (i32.eqz
+        (local.get $slMap)
+       )
+       (then
+        (call $~lib/builtins/abort
+         (i32.const 0)
+         (i32.const 368)
+         (i32.const 322)
+         (i32.const 18)
+        )
+        (unreachable)
+       )
+      )
+      (local.set $head
+       (call $~lib/rt/tlsf/GETHEAD
+        (local.get $root)
+        (local.get $fl)
+        (i32.ctz
+         (local.get $slMap)
+        )
+       )
+      )
+     )
+    )
+   )
+   (else
+    (local.set $head
+     (call $~lib/rt/tlsf/GETHEAD
+      (local.get $root)
+      (local.get $fl)
+      (i32.ctz
+       (local.get $slMap)
+      )
+     )
+    )
+   )
+  )
+  (return
+   (local.get $head)
+  )
+ )
+ (func $~lib/rt/tlsf/growMemory (param $root i32) (param $size i32)
+  (local $pagesBefore i32)
+  (local $pagesNeeded i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $pagesWanted i32)
+  (local $pagesAfter i32)
+  (drop
+   (i32.const 0)
+  )
+  (if
+   (i32.ge_u
+    (local.get $size)
+    (i32.const 256)
+   )
+   (then
+    (local.set $size
+     (call $~lib/rt/tlsf/roundSize
+      (local.get $size)
+     )
+    )
+   )
+  )
+  (local.set $pagesBefore
+   (memory.size)
+  )
+  (local.set $size
+   (i32.add
+    (local.get $size)
+    (i32.shl
+     (i32.const 4)
+     (i32.ne
+      (i32.sub
+       (i32.shl
+        (local.get $pagesBefore)
+        (i32.const 16)
+       )
+       (i32.const 4)
+      )
+      (call $~lib/rt/tlsf/GETTAIL
+       (local.get $root)
+      )
+     )
+    )
+   )
+  )
+  (local.set $pagesNeeded
+   (i32.shr_u
+    (i32.and
+     (i32.add
+      (local.get $size)
+      (i32.const 65535)
+     )
+     (i32.xor
+      (i32.const 65535)
+      (i32.const -1)
+     )
+    )
+    (i32.const 16)
+   )
+  )
+  (local.set $pagesWanted
+   (select
+    (local.tee $4
+     (local.get $pagesBefore)
+    )
+    (local.tee $5
+     (local.get $pagesNeeded)
+    )
+    (i32.gt_s
+     (local.get $4)
+     (local.get $5)
+    )
+   )
+  )
+  (if
+   (i32.lt_s
+    (memory.grow
+     (local.get $pagesWanted)
+    )
+    (i32.const 0)
+   )
+   (then
+    (if
+     (i32.lt_s
+      (memory.grow
+       (local.get $pagesNeeded)
+      )
+      (i32.const 0)
+     )
+     (then
+      (unreachable)
+     )
+    )
+   )
+  )
+  (local.set $pagesAfter
+   (memory.size)
+  )
+  (drop
+   (call $~lib/rt/tlsf/addMemory
+    (local.get $root)
+    (i32.shl
+     (local.get $pagesBefore)
+     (i32.const 16)
+    )
+    (i64.shl
+     (i64.extend_i32_s
+      (local.get $pagesAfter)
+     )
+     (i64.const 16)
+    )
+   )
+  )
+ )
+ (func $~lib/rt/tlsf/prepareBlock (param $root i32) (param $block i32) (param $size i32)
+  (local $blockInfo i32)
+  (local $remaining i32)
+  (local $spare i32)
+  (local $6 i32)
+  (local.set $blockInfo
+   (call $~lib/rt/common/BLOCK#get:mmInfo
+    (local.get $block)
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (i32.eqz
+     (i32.and
+      (i32.add
+       (local.get $size)
+       (i32.const 4)
+      )
+      (i32.const 15)
+     )
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 368)
+     (i32.const 336)
+     (i32.const 14)
+    )
+    (unreachable)
+   )
+  )
+  (local.set $remaining
+   (i32.sub
+    (i32.and
+     (local.get $blockInfo)
+     (i32.xor
+      (i32.const 3)
+      (i32.const -1)
+     )
+    )
+    (local.get $size)
+   )
+  )
+  (if
+   (i32.ge_u
+    (local.get $remaining)
+    (i32.add
+     (i32.const 4)
+     (i32.const 12)
+    )
+   )
+   (then
+    (call $~lib/rt/common/BLOCK#set:mmInfo
+     (local.get $block)
+     (i32.or
+      (local.get $size)
+      (i32.and
+       (local.get $blockInfo)
+       (i32.const 2)
+      )
+     )
+    )
+    (local.set $spare
+     (i32.add
+      (i32.add
+       (local.get $block)
+       (i32.const 4)
+      )
+      (local.get $size)
+     )
+    )
+    (call $~lib/rt/common/BLOCK#set:mmInfo
+     (local.get $spare)
+     (i32.or
+      (i32.sub
+       (local.get $remaining)
+       (i32.const 4)
+      )
+      (i32.const 1)
+     )
+    )
+    (call $~lib/rt/tlsf/insertBlock
+     (local.get $root)
+     (local.get $spare)
+    )
+   )
+   (else
+    (call $~lib/rt/common/BLOCK#set:mmInfo
+     (local.get $block)
+     (i32.and
+      (local.get $blockInfo)
+      (i32.xor
+       (i32.const 1)
+       (i32.const -1)
+      )
+     )
+    )
+    (local.set $6
+     (call $~lib/rt/tlsf/GETRIGHT
+      (local.get $block)
+     )
+    )
+    (call $~lib/rt/common/BLOCK#set:mmInfo
+     (local.get $6)
+     (i32.and
+      (call $~lib/rt/common/BLOCK#get:mmInfo
+       (local.get $6)
+      )
+      (i32.xor
+       (i32.const 2)
+       (i32.const -1)
+      )
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/rt/tlsf/allocateBlock (param $root i32) (param $size i32) (result i32)
+  (local $payloadSize i32)
+  (local $block i32)
+  (local.set $payloadSize
+   (call $~lib/rt/tlsf/prepareSize
+    (local.get $size)
+   )
+  )
+  (local.set $block
+   (call $~lib/rt/tlsf/searchBlock
+    (local.get $root)
+    (local.get $payloadSize)
+   )
+  )
+  (if
+   (i32.eqz
+    (local.get $block)
+   )
+   (then
+    (call $~lib/rt/tlsf/growMemory
+     (local.get $root)
+     (local.get $payloadSize)
+    )
+    (local.set $block
+     (call $~lib/rt/tlsf/searchBlock
+      (local.get $root)
+      (local.get $payloadSize)
+     )
+    )
+    (drop
+     (i32.const 1)
+    )
+    (if
+     (i32.eqz
+      (local.get $block)
+     )
+     (then
+      (call $~lib/builtins/abort
+       (i32.const 0)
+       (i32.const 368)
+       (i32.const 472)
+       (i32.const 16)
+      )
+      (unreachable)
+     )
+    )
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (i32.ge_u
+     (i32.and
+      (call $~lib/rt/common/BLOCK#get:mmInfo
+       (local.get $block)
+      )
+      (i32.xor
+       (i32.const 3)
+       (i32.const -1)
+      )
+     )
+     (local.get $payloadSize)
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 368)
+     (i32.const 474)
+     (i32.const 14)
+    )
+    (unreachable)
+   )
+  )
+  (call $~lib/rt/tlsf/removeBlock
+   (local.get $root)
+   (local.get $block)
+  )
+  (call $~lib/rt/tlsf/prepareBlock
+   (local.get $root)
+   (local.get $block)
+   (local.get $payloadSize)
+  )
+  (return
+   (local.get $block)
+  )
+ )
+ (func $~lib/rt/tlsf/__alloc (param $size i32) (result i32)
+  (if
+   (i32.eqz
+    (global.get $~lib/rt/tlsf/ROOT)
+   )
+   (then
+    (call $~lib/rt/tlsf/initialize)
+   )
+  )
+  (return
+   (i32.add
+    (call $~lib/rt/tlsf/allocateBlock
+     (global.get $~lib/rt/tlsf/ROOT)
+     (local.get $size)
+    )
+    (i32.const 4)
+   )
+  )
+ )
+ (func $~lib/rt/itcms/Object#set:rtId (param $this i32) (param $rtId i32)
+  (i32.store offset=12
+   (local.get $this)
+   (local.get $rtId)
+  )
+ )
+ (func $~lib/rt/itcms/Object#set:rtSize (param $this i32) (param $rtSize i32)
+  (i32.store offset=16
+   (local.get $this)
+   (local.get $rtSize)
+  )
+ )
+ (func $~lib/rt/itcms/__new (param $size i32) (param $id i32) (result i32)
+  (local $obj i32)
+  (local $ptr i32)
+  (if
+   (i32.ge_u
+    (local.get $size)
+    (i32.const 1073741804)
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 32)
+     (i32.const 96)
+     (i32.const 262)
+     (i32.const 31)
+    )
+    (unreachable)
+   )
+  )
+  (if
+   (i32.ge_u
+    (global.get $~lib/rt/itcms/total)
+    (global.get $~lib/rt/itcms/threshold)
+   )
+   (then
+    (call $~lib/rt/itcms/interrupt)
+   )
+  )
+  (local.set $obj
+   (i32.sub
+    (call $~lib/rt/tlsf/__alloc
+     (i32.add
+      (i32.const 16)
+      (local.get $size)
+     )
+    )
+    (i32.const 4)
+   )
+  )
+  (call $~lib/rt/itcms/Object#set:rtId
+   (local.get $obj)
+   (local.get $id)
+  )
+  (call $~lib/rt/itcms/Object#set:rtSize
+   (local.get $obj)
+   (local.get $size)
+  )
+  (call $~lib/rt/itcms/Object#linkTo
+   (local.get $obj)
+   (global.get $~lib/rt/itcms/fromSpace)
+   (global.get $~lib/rt/itcms/white)
+  )
+  (global.set $~lib/rt/itcms/total
+   (i32.add
+    (global.get $~lib/rt/itcms/total)
+    (call $~lib/rt/itcms/Object#get:size
+     (local.get $obj)
+    )
+   )
+  )
+  (local.set $ptr
+   (i32.add
+    (local.get $obj)
+    (i32.const 20)
+   )
+  )
+  (memory.fill
+   (local.get $ptr)
+   (i32.const 0)
+   (local.get $size)
+  )
+  (return
+   (local.get $ptr)
+  )
+ )
+ (func $~lib/rt/__newTuple (param $elementSize i32) (param $bitmap i64) (result i32)
+  (local $totalSize i32)
+  (local $ptr i32)
+  (local.set $totalSize
+   (i32.add
+    (local.get $elementSize)
+    (i32.const 8)
+   )
+  )
+  (local.set $ptr
+   (call $~lib/rt/itcms/__new
+    (local.get $totalSize)
+    (i32.const 4)
+   )
+  )
+  (i64.store
+   (i32.add
+    (local.get $ptr)
+    (local.get $elementSize)
+   )
+   (local.get $bitmap)
+  )
+  (return
+   (local.get $ptr)
+  )
+ )
+ (func $~lib/rt/itcms/__link (param $parentPtr i32) (param $childPtr i32) (param $expectMultiple i32)
+  (local $child i32)
+  (local $parent i32)
+  (local $parentColor i32)
+  (if
+   (i32.eqz
+    (local.get $childPtr)
+   )
+   (then
+    (return)
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (if
+   (i32.eqz
+    (local.get $parentPtr)
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 96)
+     (i32.const 296)
+     (i32.const 14)
+    )
+    (unreachable)
+   )
+  )
+  (local.set $child
+   (i32.sub
+    (local.get $childPtr)
+    (i32.const 20)
+   )
+  )
+  (if
+   (i32.eq
+    (call $~lib/rt/itcms/Object#get:color
+     (local.get $child)
+    )
+    (global.get $~lib/rt/itcms/white)
+   )
+   (then
+    (local.set $parent
+     (i32.sub
+      (local.get $parentPtr)
+      (i32.const 20)
+     )
+    )
+    (local.set $parentColor
+     (call $~lib/rt/itcms/Object#get:color
+      (local.get $parent)
+     )
+    )
+    (if
+     (i32.eq
+      (local.get $parentColor)
+      (i32.eqz
+       (global.get $~lib/rt/itcms/white)
+      )
+     )
+     (then
+      (if
+       (local.get $expectMultiple)
+       (then
+        (call $~lib/rt/itcms/Object#makeGray
+         (local.get $parent)
+        )
+       )
+       (else
+        (call $~lib/rt/itcms/Object#makeGray
+         (local.get $child)
+        )
+       )
+      )
+     )
+     (else
+      (if
+       (if (result i32)
+        (i32.eq
+         (local.get $parentColor)
+         (i32.const 3)
+        )
+        (then
+         (i32.eq
+          (global.get $~lib/rt/itcms/state)
+          (i32.const 1)
+         )
+        )
+        (else
+         (i32.const 0)
+        )
+       )
+       (then
+        (call $~lib/rt/itcms/Object#makeGray
+         (local.get $child)
+        )
+       )
+      )
+     )
+    )
+   )
+  )
+ )
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+  (local $elementPtr i32)
+  (local.set $elementPtr
+   (i32.add
+    (local.get $this)
+    (local.get $offset)
+   )
+  )
+  (i32.store
+   (local.get $elementPtr)
+   (local.get $value)
+  )
+  (drop
+   (i32.const 1)
+  )
+  (call $~lib/rt/itcms/__link
+   (local.get $this)
+   (local.get $value)
+   (i32.const 0)
+  )
+ )
+ (func $closure-tmp-function/getFunction~anonymous|0 (result i32)
+  (local $0 i32)
+  (local.set $0
+   (call $~lib/rt/__localtostack
+    (call $~lib/rt/__newTuple
+     (i32.const 4)
+     (i64.const 1)
+    )
+   )
+  )
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/rt/__tmptostack
+    (local.get $0)
+   )
+   (i32.const 0)
+   (call $~lib/rt/__tmptostack
+    (call $~lib/rt/closure/getClosureEnv)
+   )
+  )
+  (return
+   (i32.add
+    (call $~lib/tuple/SmallTuple#__get<i32>
+     (call $~lib/rt/__tmptostack
+      (call $~lib/rt/closure/getClosureEnvByLevel
+       (i32.const 1)
+      )
+     )
+     (i32.const 4)
+    )
+    (i32.const 1)
+   )
+  )
+ )
+ (func $~lib/rt/__newFunction (param $functionIdnex i32) (param $env i32) (param $rtid i32) (result i32)
+  (local $ptr i32)
+  (local.set $ptr
+   (call $~lib/rt/itcms/__new
+    (i32.const 8)
+    (local.get $rtid)
+   )
+  )
+  (i32.store
+   (local.get $ptr)
+   (local.get $functionIdnex)
+  )
+  (i32.store
+   (i32.add
+    (local.get $ptr)
+    (i32.const 4)
+   )
+   (local.get $env)
+  )
+  (return
+   (local.get $ptr)
+  )
+ )
+ (func $closure-tmp-function/getFunction (result i32)
+  (local $0 i32)
+  (local $aaa i32)
+  (local.set $0
+   (call $~lib/rt/__localtostack
+    (call $~lib/rt/__newTuple
+     (i32.const 8)
+     (i64.const 1)
+    )
+   )
+  )
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/rt/__tmptostack
+    (local.get $0)
+   )
+   (i32.const 0)
+   (call $~lib/rt/__tmptostack
+    (call $~lib/rt/closure/getClosureEnv)
+   )
+  )
+  (call $~lib/tuple/SmallTuple#__set<i32>
+   (call $~lib/rt/__tmptostack
+    (local.get $0)
+   )
+   (i32.const 4)
+   (i32.const 5)
+  )
+  (return
+   (call $~lib/rt/__newFunction
+    (i32.const 1)
+    (local.get $0)
+    (i32.const 5)
+   )
+  )
+ )
+ (func $closure-tmp-function/foo (result i32)
+  (local $0 i32)
+  (return
+   (block (result i32)
+    (local.set $0
+     (block (result i32)
+      (call $~lib/rt/closure/setClosureEnv
+       (i32.const 0)
+      )
+      (call $closure-tmp-function/getFunction)
+     )
+    )
+    (call_indirect (type $4)
+     (block (result i32)
+      (call $~lib/rt/closure/setClosureEnv
+       (i32.load offset=4
+        (local.get $0)
+       )
+      )
+      (global.set $~argumentsLength
+       (i32.const 0)
+      )
+      (i32.load
+       (local.get $0)
+      )
+     )
+    )
+   )
+  )
+ )
+ (func $start:closure-tmp-function
+  (global.set $~lib/rt/itcms/threshold
+   (i32.shr_u
+    (i32.sub
+     (i32.shl
+      (memory.size)
+      (i32.const 16)
+     )
+     (global.get $~lib/memory/__heap_base)
+    )
+    (i32.const 1)
+   )
+  )
+  (global.set $~lib/rt/itcms/pinSpace
+   (call $~lib/rt/itcms/initLazy
+    (i32.const 144)
+   )
+  )
+  (global.set $~lib/rt/itcms/toSpace
+   (call $~lib/rt/itcms/initLazy
+    (i32.const 176)
+   )
+  )
+  (global.set $~lib/rt/itcms/fromSpace
+   (call $~lib/rt/itcms/initLazy
+    (i32.const 320)
+   )
+  )
+  (if
+   (i32.eqz
+    (i32.eq
+     (call $closure-tmp-function/foo)
+     (i32.const 6)
+    )
+   )
+   (then
+    (call $~lib/builtins/abort
+     (i32.const 0)
+     (i32.const 432)
+     (i32.const 12)
+     (i32.const 1)
+    )
+    (unreachable)
+   )
+  )
+ )
+ (func $~lib/rt/__visit_globals (param $0 i32)
+  (local $1 i32)
+  (nop)
+ )
+ (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  (call $~lib/object/Object~visit
+   (local.get $0)
+   (local.get $1)
+  )
+  (call $~lib/rt/itcms/__visit
+   (i32.load
+    (local.get $0)
+   )
+   (local.get $1)
+  )
+ )
+ (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
+  (nop)
+ )
+ (func $~lib/rt/common/OBJECT#get:rtSize (param $this i32) (result i32)
+  (i32.load offset=16
+   (local.get $this)
+  )
+ )
+ (func $~lib/tuple/SmallTuple#__visit (param $this i32) (param $cookie i32)
+  (local $rtSize i32)
+  (local $elemntCount i32)
+  (local $bitmap i64)
+  (local $i i32)
+  (local $elementPtr i32)
+  (local.set $rtSize
+   (call $~lib/rt/common/OBJECT#get:rtSize
+    (i32.sub
+     (local.get $this)
+     (i32.const 20)
+    )
+   )
+  )
+  (local.set $elemntCount
+   (i32.shr_u
+    (i32.sub
+     (local.get $rtSize)
+     (i32.const 8)
+    )
+    (i32.const 2)
+   )
+  )
+  (local.set $bitmap
+   (i64.load
+    (i32.sub
+     (i32.add
+      (local.get $this)
+      (local.get $rtSize)
+     )
+     (i32.const 8)
+    )
+   )
+  )
+  (local.set $i
+   (i32.const 0)
+  )
+  (loop $for-loop|0
+   (if
+    (i32.lt_u
+     (local.get $i)
+     (local.get $elemntCount)
+    )
+    (then
+     (if
+      (i64.ne
+       (i64.and
+        (local.get $bitmap)
+        (i64.shl
+         (i64.const 1)
+         (i64.extend_i32_u
+          (local.get $i)
+         )
+        )
+       )
+       (i64.const 0)
+      )
+      (then
+       (local.set $elementPtr
+        (i32.add
+         (local.get $this)
+         (i32.shl
+          (local.get $i)
+          (i32.const 2)
+         )
+        )
+       )
+       (call $~lib/rt/itcms/__visit
+        (i32.load
+         (local.get $elementPtr)
+        )
+        (local.get $cookie)
+       )
+      )
+     )
+     (local.set $i
+      (i32.add
+       (local.get $i)
+       (i32.const 1)
+      )
+     )
+     (br $for-loop|0)
+    )
+   )
+  )
+ )
+ (func $~lib/tuple/SmallTuple~visit (param $0 i32) (param $1 i32)
+  (call $~lib/object/Object~visit
+   (local.get $0)
+   (local.get $1)
+  )
+  (call $~lib/tuple/SmallTuple#__visit
+   (local.get $0)
+   (local.get $1)
+  )
+ )
+ (func $~lib/function/Function<%28%29=>i32>#get:_env (param $this i32) (result i32)
+  (i32.load offset=4
+   (local.get $this)
+  )
+ )
+ (func $~lib/function/Function<%28%29=>i32>#__visit (param $this i32) (param $cookie i32)
+  (call $~lib/rt/itcms/__visit
+   (call $~lib/function/Function<%28%29=>i32>#get:_env
+    (call $~lib/rt/__tmptostack
+     (local.get $this)
+    )
+   )
+   (local.get $cookie)
+  )
+ )
+ (func $~lib/function/Function<%28%29=>i32>~visit (param $0 i32) (param $1 i32)
+  (call $~lib/object/Object~visit
+   (local.get $0)
+   (local.get $1)
+  )
+  (call $~lib/function/Function<%28%29=>i32>#__visit
+   (local.get $0)
+   (local.get $1)
+  )
+ )
+ (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
+  (block $invalid
+   (block $~lib/function/Function<%28%29=>i32>
+    (block $~lib/tuple/SmallTuple
+     (block $~lib/arraybuffer/ArrayBufferView
+      (block $~lib/string/String
+       (block $~lib/arraybuffer/ArrayBuffer
+        (block $~lib/object/Object
+         (br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $~lib/tuple/SmallTuple $~lib/function/Function<%28%29=>i32> $invalid
+          (i32.load
+           (i32.sub
+            (local.get $0)
+            (i32.const 8)
+           )
+          )
+         )
+        )
+        (return)
+       )
+       (return)
+      )
+      (return)
+     )
+     (block
+      (call $~lib/arraybuffer/ArrayBufferView~visit
+       (local.get $0)
+       (local.get $1)
+      )
+      (return)
+     )
+    )
+    (block
+     (call $~lib/tuple/SmallTuple~visit
+      (local.get $0)
+      (local.get $1)
+     )
+     (return)
+    )
+   )
+   (block
+    (call $~lib/function/Function<%28%29=>i32>~visit
+     (local.get $0)
+     (local.get $1)
+    )
+    (return)
+   )
+  )
+  (unreachable)
+ )
+ (func $~start
+  (call $start:closure-tmp-function)
+ )
+)

--- a/tests/frontend/compiler/closure-tmp-function.wat
+++ b/tests/frontend/compiler/closure-tmp-function.wat
@@ -3,8 +3,8 @@
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
- (type $4 (func (result i32)))
- (type $5 (func (param i32 i32) (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (result i32)))
  (type $6 (func))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 496))
  (global $~lib/memory/__data_end i32 (i32.const 524))
@@ -3112,7 +3112,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3169,7 +3169,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3199,7 +3199,7 @@
       (call $closure-tmp-function/getFunction)
      )
     )
-    (call_indirect (type $4)
+    (call_indirect (type $5)
      (block (result i32)
       (call $~lib/rt/closure/setClosureEnv
        (i32.load offset=4
@@ -3265,7 +3265,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-two-funcs.opt.wat
+++ b/tests/frontend/compiler/closure-two-funcs.opt.wat
@@ -19,8 +19,8 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33276))
  (global $~lib/rt/closure/env (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33276))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -42,6 +42,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-two-funcs.wat
+++ b/tests/frontend/compiler/closure-two-funcs.wat
@@ -3,8 +3,8 @@
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func (param i32 i32 i32)))
- (type $4 (func (result i32)))
- (type $5 (func (param i32 i32) (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (result i32)))
  (type $6 (func))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i32) (result i32)))
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 480))
  (global $~lib/memory/__data_end i32 (i32.const 508))
@@ -3111,7 +3111,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3167,7 +3167,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3203,7 +3203,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
@@ -3237,7 +3237,7 @@
   )
   (return
    (i32.add
-    (call_indirect (type $4)
+    (call_indirect (type $5)
      (block (result i32)
       (call $~lib/rt/closure/setClosureEnv
        (i32.load offset=4
@@ -3252,7 +3252,7 @@
       )
      )
     )
-    (call_indirect (type $4)
+    (call_indirect (type $5)
      (block (result i32)
       (call $~lib/rt/closure/setClosureEnv
        (i32.load offset=4
@@ -3325,7 +3325,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)

--- a/tests/frontend/compiler/closure-use-before-assigned.opt.wat
+++ b/tests/frontend/compiler/closure-use-before-assigned.opt.wat
@@ -41,6 +41,12 @@
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $~lib/rt/closure/env
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
   global.get $~lib/rt/itcms/pinSpace
   local.tee $1
   i32.load offset=4

--- a/tests/frontend/compiler/closure-use-before-assigned.wat
+++ b/tests/frontend/compiler/closure-use-before-assigned.wat
@@ -1,8 +1,8 @@
 (module
  (type $0 (func (param i32) (result i32)))
  (type $1 (func (param i32 i32)))
- (type $2 (func (result i32)))
- (type $3 (func (param i32)))
+ (type $2 (func (param i32)))
+ (type $3 (func (result i32)))
  (type $4 (func (param i32 i32 i32)))
  (type $5 (func (param i32 i32) (result i32)))
  (type $6 (func))
@@ -12,7 +12,6 @@
  (type $10 (func (param i32 i64) (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/getClosureEnvByLevel" (func $~lib/rt/closure/getClosureEnvByLevel (param i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (import "as-builtin-fn" "~lib/rt/closure/getClosureEnv" (func $~lib/rt/closure/getClosureEnv (result i32)))
  (import "as-builtin-fn" "~lib/rt/closure/setClosureEnv" (func $~lib/rt/closure/setClosureEnv (param i32)))
  (import "as-builtin-fn" "~lib/rt/__localtostack" (func $~lib/rt/__localtostack (param i32) (result i32)))
  (import "as-builtin-fn" "~lib/rt/__tmptostack" (func $~lib/rt/__tmptostack (param i32) (result i32)))
@@ -29,6 +28,7 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~argumentsLength (mut i32) (i32.const 0))
  (global $~lib/rt/__rtti_base i32 (i32.const 496))
  (global $~lib/memory/__data_end i32 (i32.const 524))
@@ -3096,7 +3096,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3167,7 +3167,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (drop
@@ -3189,7 +3189,7 @@
    (i32.const 1)
   )
   (return
-   (call_indirect (type $2)
+   (call_indirect (type $3)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3222,7 +3222,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (return
@@ -3256,7 +3256,7 @@
    )
    (i32.const 0)
    (call $~lib/rt/__tmptostack
-    (call $~lib/rt/closure/getClosureEnv)
+    (global.get $~lib/rt/closure/env)
    )
   )
   (drop
@@ -3271,7 +3271,7 @@
    )
   )
   (local.set $before
-   (call_indirect (type $2)
+   (call_indirect (type $3)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3295,7 +3295,7 @@
    (i32.const 1)
   )
   (local.set $after
-   (call_indirect (type $2)
+   (call_indirect (type $3)
     (block (result i32)
      (call $~lib/rt/closure/setClosureEnv
       (i32.load offset=4
@@ -3407,7 +3407,17 @@
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  (nop)
+  (if
+   (local.tee $1
+    (global.get $~lib/rt/closure/env)
+   )
+   (then
+    (call $~lib/rt/itcms/__visit
+     (local.get $1)
+     (local.get $0)
+    )
+   )
+  )
  )
  (func $~lib/arraybuffer/ArrayBufferView~visit (param $0 i32) (param $1 i32)
   (local $2 i32)


### PR DESCRIPTION
The global ~lib/rt/closure/env is used pass function._env, which is a managed object. If the global is not tracked by GC, this object may be collected when callee new closure tuple