### PR TITLE
fix(as): clean ~lib/rt/closure/env after getClosureEnv

### DIFF
--- a/assemblyscript/src/compiler.ts
+++ b/assemblyscript/src/compiler.ts
@@ -754,6 +754,10 @@ export class Compiler extends DiagnosticEmitter {
     return this.module.get_closure_env_by_level(level);
   }
 
+  clearClosureEnv(): ExpressionRef {
+    return this.module.global_set(BuiltinNames.closureEnv, this.makeZero(Type.usize32));
+  }
+
   private initDefaultMemory(memoryOffset: i64): void {
     this.memoryOffset = memoryOffset;
 
@@ -1709,7 +1713,8 @@ export class Compiler extends DiagnosticEmitter {
       const heapLocalsStmt = module.local_set(heapLocalsStorage.index, heapLocalsTuple, true);
       functionClosurePrepareStmts.push(heapLocalsStmt);
       const parentEnvElementInfo = tupleInfo.elements[0];
-      const getClosureEnvStmt = this.getClosureEnv();
+      const nestedLevel = instance.prototype.nestedLevel;
+      const getClosureEnvStmt = nestedLevel > 0 ? this.getClosureEnv() : this.makeZero(Type.usize32);
       const parentEnvSetter = assert(this.program.smallTupleInstance.getMethod("__set", [parentEnvElementInfo.type]));
       const saveParentEnvStmt = this.makeCallDirect(
         parentEnvSetter,
@@ -1722,6 +1727,9 @@ export class Compiler extends DiagnosticEmitter {
       );
 
       functionClosurePrepareStmts.push(saveParentEnvStmt);
+      if (nestedLevel > 0) {
+        functionClosurePrepareStmts.push(this.clearClosureEnv());
+      }
 
       const thisCount = signature.thisType ? 1 : 0;
       for (let i = 0; i < thisCount + numParameters; i++) {
@@ -9157,7 +9165,7 @@ export class Compiler extends DiagnosticEmitter {
   private makeNewFunction(functionIndex: i32, envLocal: Local | null, rtid: u32, reportNode: Node): ExpressionRef {
     const program = this.program;
     const module = this.module;
-    const envExpr = envLocal ? module.local_get(envLocal.index, TypeRef.I32) : module.i32(0);
+    const envExpr = envLocal ? module.local_get(envLocal.index, TypeRef.I32) : this.makeZero(Type.usize32);
     const expr = this.makeCallDirect(
       program.newFunctionInstance,
       [module.usize(functionIndex), envExpr, module.i32(rtid)],

--- a/assemblyscript/src/program.ts
+++ b/assemblyscript/src/program.ts
@@ -4475,7 +4475,11 @@ export class Function extends TypedElement {
   pushClosureScope(closureInfo: ClosureFunctionInfo, storage: Local | null = null): void {
     let program = this.prototype.program;
     let builder = new TupleTypeBuilder(program, program.registeredTupleTypes);
-    builder.push(program.smallTupleInstance.type, this.prototype.declarationBase.nameRange, ReportMode.Report);
+    builder.push(
+      program.smallTupleInstance.type.asNullable(),
+      this.prototype.declarationBase.nameRange,
+      ReportMode.Report
+    );
     this.closureScopeStack_.push(new ClosureScopeFrame(builder, closureInfo, storage));
   }
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -120,6 +120,11 @@ function getThemeConfig(language: "en" | "zh-CN"): DefaultTheme.Config {
             items: listItems("tech/infra"),
           },
           {
+            text: "GC",
+            link: "/tech/gc/debugging_gc_bugs",
+            items: listItems("tech/gc"),
+          },
+          {
             text: "For Developers",
             items: [
               {

--- a/docs/tech/gc/debugging_gc_bugs.md
+++ b/docs/tech/gc/debugging_gc_bugs.md
@@ -1,0 +1,109 @@
+# Debugging GC Bugs
+
+## Note on Minimal Reproduction
+
+Creating a minimal reproduction for GC bugs is often difficult.
+
+Reason: removing code can change GC execution order (`__new` and `__collect`) and change object reachability paths.
+
+In practice, changing export-function call order or removing code that looks unrelated can make the bug disappear.
+
+## Why Direct Analysis Fails
+
+1. **Heap is corrupted at crash time** - crash location is where corruption is detected, not where it happened
+2. **WAT files are 600K+ lines** - humans and AI cannot reliably analyze such massive code
+3. **Backtrace is useless** - problem occurred earlier, reasoning from crash site is futile
+
+Don't try to find root causes by reading crash backtraces or WAT files.
+
+## Systematic Trace Approach
+
+### 1. Add Trace at Boundaries
+
+Instrument GC allocation, mark, sweep, and memory access points. Answer:
+
+- What is the full lifecycle of the target object? (alloc -> refs -> GC cycles -> final state)
+- Did GC behavior match expectation? (kept alive when needed, collected when dead)
+- Is the failure class premature free, missing root/edge, stale pointer use, or unexpected retention?
+
+### 2. No Template Strings
+
+Template strings create objects during execution and change GC behavior. Results become unreliable.
+
+WRONG:
+
+```typescript
+trace(`alloc ptr=${ptr} size=${size}`);
+```
+
+CORRECT:
+
+```typescript
+__gc_trace_alloc(ptr, size); // number arguments only
+```
+
+### 3. Trace Function Pattern
+
+Runtime-level functions with numeric IDs. Strings in imported layer:
+
+E.g. in assemblyscript/std/assembly/rt.ts:
+
+```typescript
+export declare function __gc_trace_alloc(ptr: usize, size: u32, site: u32): void;
+export declare function __gc_trace_mark(ptr: usize, phase: u32): void;
+export declare function __gc_trace_sweep(ptr: usize, phase: u32): void;
+```
+
+In runtime imports:
+
+```typescript
+__gc_trace_alloc(ptr: usize, size: u32, site: u32) {
+  const labels = { 1: "new_object", 2: "new_array", 3: "clone_object" };
+  console.log(`[GC_ALLOC] ptr=0x${ptr.toString(16)} size=${size} site=${labels[site]}`);
+}
+```
+
+Emit after sensitive operations:
+
+```typescript
+obj = __new(size, idof<T>());
+__gc_trace_alloc(changetype<usize>(obj), size, siteId);
+```
+
+### 4. Collect Trace Events
+
+- `alloc ptr=0xXXX size=N` - object created
+- `free ptr=0xXXX` - object freed by GC
+- `visit ptr=0xXXX` - object marked in GC
+- `link parent=0xP child=0xC` - reference created
+- `read ptr=0xXXX from=global_name` - global accessed
+
+### 5. Ask AI Specific Questions
+
+Don't ask: "Why is my code crashing?"
+
+Instead ask AI these factual questions about trace logs:
+
+- When was object 0xNNNN allocated and who referenced it?
+- In each GC cycle, what happened to 0xNNNN?
+- Did 0xNNNN die too early, stay alive too long, or change state as expected?
+- Which edge/root transition changed its reachability?
+
+AI is reliable at pattern-matching in logs.
+
+### 6. Root Cause from Trace Facts
+
+From AI answers, identify the invariant violation pattern:
+
+For GC bugs in general:
+
+1. **Failure type** - Premature free, stale pointer use, missing root/edge, or retention leak
+2. **Check invariant** - What should have kept it alive? (GC root, live variable, etc)
+3. **Identify responsibility** - Who owns clearing/protecting it? (runtime, IR lowering, GC)
+4. **Design fix** - Add missing clear/protect at the right abstraction level
+
+## Note on Release Builds
+
+This method may not work in release builds.
+
+Reason: adding import calls for tracing can change optimization behavior in passes, so code shape and lifetime patterns may differ from the original release binary.

--- a/tests/frontend/compiler/closure-arrow-in-function.opt.wat
+++ b/tests/frontend/compiler/closure-arrow-in-function.opt.wat
@@ -1514,7 +1514,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1581,7 +1581,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1612,8 +1614,8 @@
   i64.store
   local.get $0
   local.tee $1
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $0
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-arrow-in-function.wat
+++ b/tests/frontend/compiler/closure-arrow-in-function.wat
@@ -3074,7 +3074,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3105,7 +3105,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3113,6 +3113,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3179,14 +3182,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-basic.opt.wat
+++ b/tests/frontend/compiler/closure-basic.opt.wat
@@ -1515,7 +1515,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1582,7 +1582,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1602,8 +1604,8 @@
   i64.const 1
   i64.store
   local.get $1
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-basic.wat
+++ b/tests/frontend/compiler/closure-basic.wat
@@ -3074,7 +3074,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3105,7 +3105,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3113,6 +3113,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3163,14 +3166,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-capture-block-scope.opt.wat
+++ b/tests/frontend/compiler/closure-capture-block-scope.opt.wat
@@ -1513,7 +1513,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1580,7 +1580,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1599,8 +1601,8 @@
   i64.const 1
   i64.store
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $0
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-capture-block-scope.wat
+++ b/tests/frontend/compiler/closure-capture-block-scope.wat
@@ -3074,7 +3074,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3105,7 +3105,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3113,6 +3113,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3161,14 +3164,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (local.set $x
    (i32.const 0)

--- a/tests/frontend/compiler/closure-capture-do-while-body.opt.wat
+++ b/tests/frontend/compiler/closure-capture-do-while-body.opt.wat
@@ -1519,7 +1519,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1586,7 +1586,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1625,8 +1627,8 @@
   local.get $0
   i32.store align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   loop $do-loop|0
    i32.const 16
    i32.const 4
@@ -1639,7 +1641,7 @@
    local.get $0
    local.tee $3
    local.get $2
-   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    local.get $0
    i32.const 4
    i32.add

--- a/tests/frontend/compiler/closure-capture-do-while-body.wat
+++ b/tests/frontend/compiler/closure-capture-do-while-body.wat
@@ -3077,7 +3077,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3108,7 +3108,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3116,6 +3116,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3165,14 +3168,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (local.set $i
    (i32.const 0)
@@ -3186,7 +3187,7 @@
      )
     )
    )
-   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     (call $~lib/rt/__tmptostack
      (local.get $2)
     )

--- a/tests/frontend/compiler/closure-capture-do-while-upper-level.opt.wat
+++ b/tests/frontend/compiler/closure-capture-do-while-upper-level.opt.wat
@@ -1519,7 +1519,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1586,7 +1586,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1632,8 +1634,8 @@
   local.get $0
   i32.store align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $0
   i32.const 4
   i32.add
@@ -1651,7 +1653,7 @@
    local.get $0
    local.tee $3
    local.get $1
-   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    local.get $0
    i32.const 4
    i32.add

--- a/tests/frontend/compiler/closure-capture-do-while-upper-level.wat
+++ b/tests/frontend/compiler/closure-capture-do-while-upper-level.wat
@@ -3077,7 +3077,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3108,7 +3108,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3116,6 +3116,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3176,14 +3179,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3204,7 +3205,7 @@
      )
     )
    )
-   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     (call $~lib/rt/__tmptostack
      (local.get $3)
     )

--- a/tests/frontend/compiler/closure-capture-for-of-mixed.opt.wat
+++ b/tests/frontend/compiler/closure-capture-for-of-mixed.opt.wat
@@ -1631,6 +1631,8 @@
   local.get $0
   local.get $1
   call $~lib/rt/itcms/__link
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1671,13 +1673,12 @@
   local.get $1
   i32.store align=1
   local.get $1
-  global.get $~lib/rt/closure/env
-  local.tee $1
+  i32.const 0
   i32.store
-  local.get $3
   local.get $1
+  i32.const 0
   call $~lib/rt/itcms/__link
-  local.get $3
+  local.get $1
   i32.const 4
   i32.add
   i32.const 42

--- a/tests/frontend/compiler/closure-capture-for-of-mixed.wat
+++ b/tests/frontend/compiler/closure-capture-for-of-mixed.wat
@@ -3343,7 +3343,7 @@
    (local.get $ptr)
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3374,7 +3374,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3382,6 +3382,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3427,7 +3430,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3435,6 +3438,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3472,14 +3478,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3605,7 +3609,7 @@
      )
     )
    )
-   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     (call $~lib/rt/__tmptostack
      (local.get $9)
     )

--- a/tests/frontend/compiler/closure-capture-loop-control-var.opt.wat
+++ b/tests/frontend/compiler/closure-capture-loop-control-var.opt.wat
@@ -1519,7 +1519,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1586,7 +1586,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1625,8 +1627,8 @@
   local.get $0
   i32.store offset=4 align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   loop $for-loop|0
    i32.const 16
    i32.const 4
@@ -1641,7 +1643,7 @@
    i32.store align=1
    local.get $0
    local.get $2
-   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    local.get $0
    i32.const 4
    i32.add

--- a/tests/frontend/compiler/closure-capture-loop-control-var.wat
+++ b/tests/frontend/compiler/closure-capture-loop-control-var.wat
@@ -3061,7 +3061,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3092,7 +3092,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3100,6 +3100,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3164,14 +3167,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (local.set $iii
    (i32.const 0)
@@ -3185,7 +3186,7 @@
      )
     )
    )
-   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     (call $~lib/rt/__tmptostack
      (local.get $1)
     )

--- a/tests/frontend/compiler/closure-capture-loop-double-init.opt.wat
+++ b/tests/frontend/compiler/closure-capture-loop-double-init.opt.wat
@@ -1519,7 +1519,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1586,7 +1586,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1632,8 +1634,8 @@
   local.get $0
   i32.store offset=4 align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   i32.const 10
   local.set $1
   loop $for-loop|0
@@ -1650,7 +1652,7 @@
    i32.store align=1
    local.get $0
    local.get $2
-   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    local.get $0
    i32.const 4
    i32.add

--- a/tests/frontend/compiler/closure-capture-loop-double-init.wat
+++ b/tests/frontend/compiler/closure-capture-loop-double-init.wat
@@ -3061,7 +3061,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3092,7 +3092,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3100,6 +3100,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3175,14 +3178,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (block
    (local.set $i
@@ -3201,7 +3202,7 @@
      )
     )
    )
-   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     (call $~lib/rt/__tmptostack
      (local.get $1)
     )

--- a/tests/frontend/compiler/closure-capture-loop-mixed.opt.wat
+++ b/tests/frontend/compiler/closure-capture-loop-mixed.opt.wat
@@ -1519,7 +1519,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1586,7 +1586,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1623,8 +1625,8 @@
   local.get $2
   i32.store align=1
   local.get $2
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $2
   i32.const 4
   i32.add
@@ -1673,7 +1675,7 @@
    local.get $1
    local.tee $3
    local.get $2
-   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    local.get $0
    i32.const 2
    i32.lt_s

--- a/tests/frontend/compiler/closure-capture-loop-mixed.wat
+++ b/tests/frontend/compiler/closure-capture-loop-mixed.wat
@@ -3078,7 +3078,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3109,7 +3109,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3117,6 +3117,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3162,7 +3165,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3170,6 +3173,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3199,14 +3205,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3269,7 +3273,7 @@
      )
     )
    )
-   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     (call $~lib/rt/__tmptostack
      (local.get $4)
     )

--- a/tests/frontend/compiler/closure-capture-variable-in-do-while.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-do-while.opt.wat
@@ -1518,7 +1518,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1585,7 +1585,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1620,8 +1622,8 @@
   local.get $0
   i32.store align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   i32.const 16
   i32.const 4
   call $~lib/rt/itcms/__new
@@ -1632,7 +1634,7 @@
   i64.store
   local.get $1
   local.get $0
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-capture-variable-in-do-while.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-do-while.wat
@@ -3076,7 +3076,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3107,7 +3107,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3115,6 +3115,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3163,14 +3166,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (block $do-break|0
    (loop $do-loop|0
@@ -3182,7 +3183,7 @@
       )
      )
     )
-    (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+    (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
      (call $~lib/rt/__tmptostack
       (local.get $1)
      )

--- a/tests/frontend/compiler/closure-capture-variable-in-for-of-body.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-for-of-body.opt.wat
@@ -1630,6 +1630,8 @@
   local.get $0
   local.get $1
   call $~lib/rt/itcms/__link
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1670,11 +1672,10 @@
   local.get $0
   i32.store align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  local.tee $0
+  i32.const 0
   i32.store
-  local.get $3
   local.get $0
+  i32.const 0
   call $~lib/rt/itcms/__link
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/frontend/compiler/closure-capture-variable-in-for-of-body.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-for-of-body.wat
@@ -3342,7 +3342,7 @@
    (local.get $ptr)
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3373,7 +3373,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3381,6 +3381,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3435,14 +3438,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (local.set $arr
    (call $~lib/rt/__localtostack
@@ -3486,7 +3487,7 @@
      )
     )
    )
-   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     (call $~lib/rt/__tmptostack
      (local.get $3)
     )

--- a/tests/frontend/compiler/closure-capture-variable-in-for-of-upper-level.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-for-of-upper-level.opt.wat
@@ -1630,6 +1630,8 @@
   local.get $0
   local.get $1
   call $~lib/rt/itcms/__link
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1675,11 +1677,10 @@
   local.get $1
   i32.store align=1
   local.get $1
-  global.get $~lib/rt/closure/env
-  local.tee $0
+  i32.const 0
   i32.store
   local.get $1
-  local.get $0
+  i32.const 0
   call $~lib/rt/itcms/__link
   local.get $1
   i32.const 4

--- a/tests/frontend/compiler/closure-capture-variable-in-for-of-upper-level.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-for-of-upper-level.wat
@@ -3342,7 +3342,7 @@
    (local.get $ptr)
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3373,7 +3373,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3381,6 +3381,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3446,14 +3449,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3504,7 +3505,7 @@
      )
     )
    )
-   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     (call $~lib/rt/__tmptostack
      (local.get $4)
     )

--- a/tests/frontend/compiler/closure-capture-variable-in-for-of.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-for-of.opt.wat
@@ -1629,6 +1629,8 @@
   local.get $0
   local.get $1
   call $~lib/rt/itcms/__link
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1669,11 +1671,10 @@
   local.get $0
   i32.store align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  local.tee $0
+  i32.const 0
   i32.store
-  local.get $3
   local.get $0
+  i32.const 0
   call $~lib/rt/itcms/__link
   global.get $~lib/memory/__stack_pointer
   i32.const 4

--- a/tests/frontend/compiler/closure-capture-variable-in-for-of.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-for-of.wat
@@ -3342,7 +3342,7 @@
    (local.get $ptr)
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3373,7 +3373,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3381,6 +3381,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3434,14 +3437,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (local.set $arr
    (call $~lib/rt/__localtostack
@@ -3485,7 +3486,7 @@
      )
     )
    )
-   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     (call $~lib/rt/__tmptostack
      (local.get $3)
     )

--- a/tests/frontend/compiler/closure-capture-variable-in-loop-break-continue.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-loop-break-continue.opt.wat
@@ -1520,7 +1520,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1587,7 +1587,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1627,8 +1629,8 @@
   local.get $0
   i32.store align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   loop $for-loop|0
    block $for-break0
     i32.const 16
@@ -1642,7 +1644,7 @@
     local.get $0
     local.tee $4
     local.get $3
-    call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+    call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     local.get $1
     i32.const 5
     i32.lt_s

--- a/tests/frontend/compiler/closure-capture-variable-in-loop-break-continue.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-loop-break-continue.wat
@@ -3078,7 +3078,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3109,7 +3109,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3117,6 +3117,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__get<i32>
    (call $~lib/rt/__tmptostack
@@ -3165,14 +3168,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (local.set $count
    (i32.const 0)
@@ -3190,7 +3191,7 @@
       )
      )
     )
-    (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+    (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
      (call $~lib/rt/__tmptostack
       (local.get $2)
      )

--- a/tests/frontend/compiler/closure-capture-variable-in-loop-upper-level.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-loop-upper-level.opt.wat
@@ -1519,7 +1519,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1586,7 +1586,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1632,8 +1634,8 @@
   local.get $0
   i32.store align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $0
   i32.const 4
   i32.add
@@ -1651,7 +1653,7 @@
    local.get $0
    local.tee $3
    local.get $2
-   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    local.get $1
    i32.const 2
    i32.lt_s

--- a/tests/frontend/compiler/closure-capture-variable-in-loop-upper-level.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-loop-upper-level.wat
@@ -3077,7 +3077,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3108,7 +3108,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3116,6 +3116,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3176,14 +3179,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3204,7 +3205,7 @@
      )
     )
    )
-   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     (call $~lib/rt/__tmptostack
      (local.get $2)
     )

--- a/tests/frontend/compiler/closure-capture-variable-in-loop.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-loop.opt.wat
@@ -1519,7 +1519,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1586,7 +1586,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1625,8 +1627,8 @@
   local.get $0
   i32.store align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   loop $for-loop|0
    i32.const 16
    i32.const 4
@@ -1639,7 +1641,7 @@
    local.get $0
    local.tee $3
    local.get $2
-   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    local.get $1
    i32.const 2
    i32.lt_s

--- a/tests/frontend/compiler/closure-capture-variable-in-loop.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-loop.wat
@@ -3077,7 +3077,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3108,7 +3108,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3116,6 +3116,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3165,14 +3168,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (local.set $i
    (i32.const 0)
@@ -3186,7 +3187,7 @@
      )
     )
    )
-   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     (call $~lib/rt/__tmptostack
      (local.get $1)
     )

--- a/tests/frontend/compiler/closure-capture-variable-in-while.opt.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-while.opt.wat
@@ -1518,7 +1518,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1585,7 +1585,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1624,8 +1626,8 @@
   local.get $0
   i32.store align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   loop $while-continue|0
    i32.const 16
    i32.const 4
@@ -1638,7 +1640,7 @@
    local.get $0
    local.tee $3
    local.get $2
-   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    local.get $1
    i32.const 2
    i32.lt_s

--- a/tests/frontend/compiler/closure-capture-variable-in-while.wat
+++ b/tests/frontend/compiler/closure-capture-variable-in-while.wat
@@ -3077,7 +3077,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3108,7 +3108,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3116,6 +3116,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3165,14 +3168,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (local.set $i
    (i32.const 0)
@@ -3187,7 +3188,7 @@
       )
      )
     )
-    (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+    (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
      (call $~lib/rt/__tmptostack
       (local.get $2)
      )

--- a/tests/frontend/compiler/closure-capture-while-upper-level.opt.wat
+++ b/tests/frontend/compiler/closure-capture-while-upper-level.opt.wat
@@ -1518,7 +1518,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1585,7 +1585,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1631,8 +1633,8 @@
   local.get $0
   i32.store align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $0
   i32.const 4
   i32.add
@@ -1650,7 +1652,7 @@
    local.get $0
    local.tee $3
    local.get $2
-   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    local.get $1
    i32.const 2
    i32.lt_s

--- a/tests/frontend/compiler/closure-capture-while-upper-level.wat
+++ b/tests/frontend/compiler/closure-capture-while-upper-level.wat
@@ -3077,7 +3077,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3108,7 +3108,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3116,6 +3116,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3176,14 +3179,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3205,7 +3206,7 @@
       )
      )
     )
-    (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+    (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
      (call $~lib/rt/__tmptostack
       (local.get $3)
      )

--- a/tests/frontend/compiler/closure-captured-from-nonclosure.opt.wat
+++ b/tests/frontend/compiler/closure-captured-from-nonclosure.opt.wat
@@ -1518,7 +1518,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   i32.add
@@ -1588,7 +1588,9 @@
   local.get $0
   i32.const 0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1613,12 +1615,12 @@
   i64.store
   local.get $1
   i32.const 0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   local.get $0
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   i32.const 8
   i32.const 5
   call $~lib/rt/itcms/__new

--- a/tests/frontend/compiler/closure-captured-from-nonclosure.wat
+++ b/tests/frontend/compiler/closure-captured-from-nonclosure.wat
@@ -3059,7 +3059,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3091,7 +3091,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3099,6 +3099,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (block (result i32)
@@ -3185,14 +3188,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<%28%29=>i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-class-arrow-this-capture-fn.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-capture-fn.opt.wat
@@ -1521,7 +1521,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   i32.add
@@ -1591,7 +1591,9 @@
   local.get $1
   i32.const 0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   local.get $1
   i32.load
@@ -1614,7 +1616,9 @@
   local.get $0
   i32.const 0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $1
@@ -1807,12 +1811,12 @@
   i32.store align=1
   local.get $0
   i32.const 0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $0
   i32.const 4
   local.get $1
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $0
   i32.const 8
   i32.add
@@ -1832,7 +1836,7 @@
   local.get $0
   i32.const 12
   local.get $1
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   i32.const 8
   i32.const 7
   call $~lib/rt/itcms/__new

--- a/tests/frontend/compiler/closure-class-arrow-this-capture-fn.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-capture-fn.wat
@@ -3095,7 +3095,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3126,7 +3126,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
@@ -3134,6 +3134,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3237,7 +3240,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3245,6 +3248,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (block (result i32)
@@ -3322,14 +3328,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<closure-class-arrow-this-capture-fn/CaptureFunc>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-class-arrow-this-constructor.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-constructor.opt.wat
@@ -1591,6 +1591,8 @@
   local.get $0
   local.get $1
   call $~lib/rt/itcms/__link
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1744,11 +1746,10 @@
   i64.const 3
   i64.store
   local.get $1
-  global.get $~lib/rt/closure/env
-  local.tee $2
+  i32.const 0
   i32.store
   local.get $1
-  local.get $2
+  i32.const 0
   call $~lib/rt/itcms/__link
   local.get $1
   i32.const 4

--- a/tests/frontend/compiler/closure-class-arrow-this-constructor.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-constructor.wat
@@ -3069,7 +3069,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3100,7 +3100,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3108,6 +3108,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $closure-class-arrow-this-constructor/FromConstructor#get:value
@@ -3189,14 +3192,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $2)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<closure-class-arrow-this-constructor/FromConstructor>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-class-arrow-this-getter.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-getter.opt.wat
@@ -1521,7 +1521,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   i32.add
@@ -1591,7 +1591,9 @@
   local.get $0
   i32.const 0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1750,12 +1752,12 @@
   i64.store
   local.get $1
   i32.const 0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   local.get $0
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   i32.const 8
   i32.const 6
   call $~lib/rt/itcms/__new

--- a/tests/frontend/compiler/closure-class-arrow-this-getter.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-getter.wat
@@ -3084,7 +3084,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3115,7 +3115,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3123,6 +3123,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $closure-class-arrow-this-getter/FromGetter#get:value
@@ -3194,14 +3197,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<closure-class-arrow-this-getter/FromGetter>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-class-arrow-this-method.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-method.opt.wat
@@ -1521,7 +1521,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   i32.add
@@ -1591,7 +1591,9 @@
   local.get $0
   i32.const 0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1752,12 +1754,12 @@
   local.get $0
   local.tee $2
   i32.const 0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $0
   i32.const 4
   local.get $1
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   i32.const 8
   i32.const 6
   call $~lib/rt/itcms/__new

--- a/tests/frontend/compiler/closure-class-arrow-this-method.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-method.wat
@@ -3084,7 +3084,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3115,7 +3115,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3123,6 +3123,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $closure-class-arrow-this-method/FromMethod#get:value
@@ -3194,14 +3197,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<closure-class-arrow-this-method/FromMethod>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-class-arrow-this-nested.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-nested.opt.wat
@@ -1521,7 +1521,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   i32.add
@@ -1591,7 +1591,9 @@
   local.get $0
   i32.const 0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.load
@@ -1614,7 +1616,9 @@
   local.get $1
   i32.const 0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   i32.const 8
   i32.const 6
   call $~lib/rt/itcms/__new
@@ -1784,12 +1788,12 @@
   i64.store
   local.get $1
   i32.const 0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   local.get $0
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   i32.const 8
   i32.const 6
   call $~lib/rt/itcms/__new

--- a/tests/frontend/compiler/closure-class-arrow-this-nested.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-nested.wat
@@ -3084,7 +3084,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3115,7 +3115,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3123,6 +3123,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $closure-class-arrow-this-nested/MultiLevel#get:value
@@ -3173,7 +3176,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3181,6 +3184,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (local.set $inner
    (call $~lib/rt/__localtostack
@@ -3241,14 +3247,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<closure-class-arrow-this-nested/MultiLevel>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-class-arrow-this-setter.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-setter.opt.wat
@@ -1520,7 +1520,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   i32.add
@@ -1590,7 +1590,9 @@
   local.get $0
   i32.const 0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1760,12 +1762,12 @@
   i64.store
   local.get $1
   i32.const 0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   local.get $0
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 8
   i32.add

--- a/tests/frontend/compiler/closure-class-arrow-this-setter.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-setter.wat
@@ -3104,7 +3104,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3135,7 +3135,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3143,6 +3143,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $closure-class-arrow-this-setter/FromSetter#set:stored
    (call $~lib/rt/__tmptostack
@@ -3250,14 +3253,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $2)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<closure-class-arrow-this-setter/FromSetter>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-class-arrow-this-static.opt.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-static.opt.wat
@@ -1514,7 +1514,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1581,7 +1581,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   global.get $closure-class-arrow-this-static/FromStatic.value
  )
  (func $~lib/rt/__visit_members (param $0 i32)
@@ -1711,8 +1713,8 @@
   i64.const 1
   i64.store
   local.get $1
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   i32.const 8
   i32.const 5
   call $~lib/rt/itcms/__new

--- a/tests/frontend/compiler/closure-class-arrow-this-static.wat
+++ b/tests/frontend/compiler/closure-class-arrow-this-static.wat
@@ -3043,7 +3043,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3074,7 +3074,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3082,6 +3082,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (global.get $closure-class-arrow-this-static/FromStatic.value)
@@ -3121,14 +3124,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (local.set $getValue
    (call $~lib/rt/__localtostack

--- a/tests/frontend/compiler/closure-class-method-arrow.opt.wat
+++ b/tests/frontend/compiler/closure-class-method-arrow.opt.wat
@@ -1515,7 +1515,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1582,7 +1582,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1651,8 +1653,8 @@
   local.get $0
   i32.store align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $0
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-class-method-arrow.wat
+++ b/tests/frontend/compiler/closure-class-method-arrow.wat
@@ -3095,7 +3095,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3126,7 +3126,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3134,6 +3134,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3195,14 +3198,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-class-method-func.opt.wat
+++ b/tests/frontend/compiler/closure-class-method-func.opt.wat
@@ -1515,7 +1515,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1582,7 +1582,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1651,8 +1653,8 @@
   local.get $0
   i32.store align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $0
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-class-method-func.wat
+++ b/tests/frontend/compiler/closure-class-method-func.wat
@@ -3095,7 +3095,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3126,7 +3126,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3134,6 +3134,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3195,14 +3198,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-cross-level.opt.wat
+++ b/tests/frontend/compiler/closure-cross-level.opt.wat
@@ -1514,7 +1514,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1581,7 +1581,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1608,7 +1610,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.const 4
   i32.add
@@ -1649,8 +1653,8 @@
   i64.const 1
   i64.store
   local.get $1
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-cross-level.wat
+++ b/tests/frontend/compiler/closure-cross-level.wat
@@ -3074,7 +3074,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3105,7 +3105,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3113,6 +3113,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3170,7 +3173,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3178,6 +3181,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3237,14 +3243,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-ffi.opt.wat
+++ b/tests/frontend/compiler/closure-ffi.opt.wat
@@ -1534,7 +1534,7 @@
   i64.store
   local.get $2
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   i32.add
@@ -1599,7 +1599,9 @@
   local.tee $0
   i32.const 0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1625,7 +1627,9 @@
   local.tee $1
   i32.const 0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $1
   local.get $0
   i32.store
@@ -1682,12 +1686,12 @@
   call $~lib/rt/__newTuple
   local.tee $1
   i32.const 0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   local.get $0
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   i32.const 8
   i32.const 6
   call $~lib/rt/itcms/__new
@@ -1873,8 +1877,8 @@
   call $~lib/rt/__newTuple
   local.tee $1
   i32.const 0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-ffi.wat
+++ b/tests/frontend/compiler/closure-ffi.wat
@@ -3077,7 +3077,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3108,7 +3108,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3116,6 +3116,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3250,7 +3253,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
@@ -3258,6 +3261,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/warpo/ffi/ffi.set_ffi_closure_env
    (local.get $userData)
@@ -3383,14 +3389,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<%28%29=>i32>
    (call $~lib/rt/__tmptostack
@@ -3446,14 +3450,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-functype-param-shadow.opt.wat
+++ b/tests/frontend/compiler/closure-functype-param-shadow.opt.wat
@@ -1533,7 +1533,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32) (param $2 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32) (param $2 i32)
   local.get $0
   local.get $1
   i32.add
@@ -1604,7 +1604,9 @@
   local.get $1
   i32.const 0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.load
@@ -1776,12 +1778,12 @@
   i64.store
   local.get $1
   i32.const 0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   local.get $0
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   i32.const 8
   i32.const 6
   call $~lib/rt/itcms/__new

--- a/tests/frontend/compiler/closure-functype-param-shadow.wat
+++ b/tests/frontend/compiler/closure-functype-param-shadow.wat
@@ -3078,7 +3078,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3110,7 +3110,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
@@ -3118,6 +3118,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (local.set $2
    (local.get $fn)
@@ -3227,14 +3230,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<closure-functype-param-shadow/C1>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-loop-early-return.opt.wat
+++ b/tests/frontend/compiler/closure-loop-early-return.opt.wat
@@ -1516,7 +1516,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1585,7 +1585,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.set $0
@@ -1642,7 +1644,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.set $0
@@ -1874,8 +1878,8 @@
   i64.const 1
   i64.store
   local.get $3
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $3
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-loop-early-return.wat
+++ b/tests/frontend/compiler/closure-loop-early-return.wat
@@ -3089,7 +3089,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3122,7 +3122,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3130,6 +3130,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (local.set $sum
    (i32.const 0)
@@ -3244,14 +3247,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $2)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3323,7 +3324,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3331,6 +3332,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (local.set $sum
    (i32.const 0)
@@ -3413,14 +3417,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $2)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-multi-var.opt.wat
+++ b/tests/frontend/compiler/closure-multi-var.opt.wat
@@ -1514,7 +1514,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1581,7 +1581,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1605,8 +1607,8 @@
   i64.const 1
   i64.store
   local.get $2
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $2
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-multi-var.wat
+++ b/tests/frontend/compiler/closure-multi-var.wat
@@ -3074,7 +3074,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3105,7 +3105,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3113,6 +3113,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3171,14 +3174,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $2)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-nested-branch-2level.opt.wat
+++ b/tests/frontend/compiler/closure-nested-branch-2level.opt.wat
@@ -1515,7 +1515,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1583,7 +1583,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1659,7 +1661,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.const 4
   i32.add
@@ -1711,8 +1715,8 @@
   i64.const 1
   i64.store
   local.get $4
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $4
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-nested-branch-2level.wat
+++ b/tests/frontend/compiler/closure-nested-branch-2level.wat
@@ -3089,7 +3089,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3121,7 +3121,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3129,6 +3129,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (local.set $base
    (i32.add
@@ -3278,7 +3281,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3286,6 +3289,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3379,14 +3385,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $4)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<bool>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-nested-branch-3level.opt.wat
+++ b/tests/frontend/compiler/closure-nested-branch-3level.opt.wat
@@ -1515,7 +1515,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1583,7 +1583,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1656,8 +1658,8 @@
   i64.const 1
   i64.store
   local.get $3
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $3
   i32.const 4
   i32.add
@@ -1848,7 +1850,9 @@
   i64.store
   local.get $3
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $3
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-nested-branch-3level.wat
+++ b/tests/frontend/compiler/closure-nested-branch-3level.wat
@@ -3088,7 +3088,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3120,7 +3120,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3128,6 +3128,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (local.set $base
    (i32.add
@@ -3245,7 +3248,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3253,6 +3256,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3312,7 +3318,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3320,6 +3326,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3396,14 +3405,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $3)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<bool>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-nested-function-loop.opt.wat
+++ b/tests/frontend/compiler/closure-nested-function-loop.opt.wat
@@ -1533,7 +1533,7 @@
   i64.store
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1596,7 +1596,9 @@
   call $~lib/rt/__newTuple
   local.tee $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1653,7 +1655,9 @@
   i32.store align=1
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.const 4
   i32.add
@@ -1671,7 +1675,7 @@
    call $~lib/rt/__newTuple
    local.tee $1
    local.get $0
-   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    local.get $2
    i32.const 2
    i32.lt_s
@@ -1873,8 +1877,8 @@
   local.get $2
   i32.store offset=4 align=1
   local.get $2
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $2
   i32.const 4
   i32.add
@@ -1889,7 +1893,7 @@
    i32.store align=1
    local.get $0
    local.get $2
-   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    local.get $0
    i32.const 4
    i32.add

--- a/tests/frontend/compiler/closure-nested-function-loop.wat
+++ b/tests/frontend/compiler/closure-nested-function-loop.wat
@@ -3077,7 +3077,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3108,7 +3108,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3116,6 +3116,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (f64.convert_i32_s
@@ -3198,7 +3201,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3206,6 +3209,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3236,7 +3242,7 @@
      )
     )
    )
-   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     (call $~lib/rt/__tmptostack
      (local.get $2)
     )
@@ -3344,14 +3350,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3372,7 +3376,7 @@
      )
     )
    )
-   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+   (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
     (call $~lib/rt/__tmptostack
      (local.get $2)
     )

--- a/tests/frontend/compiler/closure-nested-loop.opt.wat
+++ b/tests/frontend/compiler/closure-nested-loop.opt.wat
@@ -9,17 +9,17 @@
  (type $7 (func (param i32 i32 i32)))
  (type $8 (func (param i32 i32 i64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (global $~lib/rt/itcms/toSpace (mut i32) (i32.const 0))
+ (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/visitCount (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/pinSpace (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/iter (mut i32) (i32.const 0))
+ (global $~lib/rt/itcms/toSpace (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/rt/closure/env (mut i32) (i32.const 0))
  (memory $0 1)
  (data $0 (i32.const 12) "<")
  (data $0.1 (i32.const 24) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00<")
@@ -1529,7 +1529,7 @@
   i64.store
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1593,7 +1593,9 @@
   call $~lib/rt/__newTuple
   local.tee $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.set $0
@@ -1659,8 +1661,8 @@
   i32.const 16
   call $~lib/rt/__newTuple
   local.tee $2
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $2
   i32.const 4
   i32.add
@@ -1699,7 +1701,9 @@
   call $~lib/rt/__newTuple
   local.tee $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1735,7 +1739,9 @@
   call $~lib/rt/__newTuple
   local.tee $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.const 4
   i32.add
@@ -1762,8 +1768,8 @@
   i32.const 8
   call $~lib/rt/__newTuple
   local.tee $1
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-nested-loop.wat
+++ b/tests/frontend/compiler/closure-nested-loop.wat
@@ -3075,7 +3075,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3109,7 +3109,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3117,6 +3117,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (local.set $sum
    (i32.const 0)
@@ -3227,14 +3230,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $2)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3306,7 +3307,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3314,6 +3315,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (local.set $sum
    (i32.const 0)
@@ -3374,7 +3378,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3382,6 +3386,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3441,14 +3448,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-nested.opt.wat
+++ b/tests/frontend/compiler/closure-nested.opt.wat
@@ -1515,7 +1515,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1582,7 +1582,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1604,7 +1606,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.const 4
   i32.add
@@ -1645,8 +1649,8 @@
   i64.const 1
   i64.store
   local.get $1
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-nested.wat
+++ b/tests/frontend/compiler/closure-nested.wat
@@ -3074,7 +3074,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3105,7 +3105,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3113,6 +3113,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3163,7 +3166,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3171,6 +3174,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3230,14 +3236,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-obj-attribute.opt.wat
+++ b/tests/frontend/compiler/closure-obj-attribute.opt.wat
@@ -1587,6 +1587,8 @@
   i32.const 0
   global.get $~lib/rt/closure/env
   call $~lib/tuple/SmallTuple#__set<closure-obj-attribute/Point>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1643,7 +1645,7 @@
   i32.store align=1
   local.get $0
   i32.const 0
-  global.get $~lib/rt/closure/env
+  i32.const 0
   call $~lib/tuple/SmallTuple#__set<closure-obj-attribute/Point>
   local.get $0
   i32.const 4

--- a/tests/frontend/compiler/closure-obj-attribute.wat
+++ b/tests/frontend/compiler/closure-obj-attribute.wat
@@ -3116,7 +3116,7 @@
    (local.get $ptr)
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3147,7 +3147,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3155,6 +3155,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $closure-obj-attribute/Point#set:x
    (call $~lib/rt/__tmptostack
@@ -3246,14 +3249,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<closure-obj-attribute/Point>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-obj-reassign.opt.wat
+++ b/tests/frontend/compiler/closure-obj-reassign.opt.wat
@@ -1604,6 +1604,8 @@
   i32.const 0
   global.get $~lib/rt/closure/env
   call $~lib/tuple/SmallTuple#__set<closure-obj-reassign/Box>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   i32.const 4
   i32.const 5
   call $~lib/rt/itcms/__new
@@ -1649,7 +1651,7 @@
   i32.store align=1
   local.get $0
   i32.const 0
-  global.get $~lib/rt/closure/env
+  i32.const 0
   call $~lib/tuple/SmallTuple#__set<closure-obj-reassign/Box>
   local.get $0
   i32.const 4

--- a/tests/frontend/compiler/closure-obj-reassign.wat
+++ b/tests/frontend/compiler/closure-obj-reassign.wat
@@ -3100,7 +3100,7 @@
    (local.get $ptr)
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3132,7 +3132,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3140,6 +3140,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (local.set $newObj
    (call $~lib/rt/__localtostack
@@ -3211,14 +3214,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<closure-obj-reassign/Box>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-param-nested.opt.wat
+++ b/tests/frontend/compiler/closure-param-nested.opt.wat
@@ -1515,7 +1515,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1582,7 +1582,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1608,7 +1610,9 @@
   i64.store
   local.get $1
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $1
   i32.const 4
   i32.add
@@ -1643,8 +1647,8 @@
   i64.const 1
   i64.store
   local.get $1
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-param-nested.wat
+++ b/tests/frontend/compiler/closure-param-nested.wat
@@ -3058,7 +3058,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3089,7 +3089,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3097,6 +3097,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3169,7 +3172,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
@@ -3177,6 +3180,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3225,14 +3231,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-param.opt.wat
+++ b/tests/frontend/compiler/closure-param.opt.wat
@@ -1515,7 +1515,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1582,7 +1582,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1630,8 +1632,8 @@
   i64.const 1
   i64.store
   local.get $2
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $2
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-param.wat
+++ b/tests/frontend/compiler/closure-param.wat
@@ -3074,7 +3074,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3105,7 +3105,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3113,6 +3113,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3191,14 +3194,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $2)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-set-var.opt.wat
+++ b/tests/frontend/compiler/closure-set-var.opt.wat
@@ -1515,7 +1515,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1582,7 +1582,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   local.tee $0
@@ -1624,8 +1626,8 @@
   local.get $1
   i32.store align=1
   local.get $1
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-set-var.wat
+++ b/tests/frontend/compiler/closure-set-var.wat
@@ -3074,7 +3074,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3105,7 +3105,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3113,6 +3113,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3169,14 +3172,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-skip-level.opt.wat
+++ b/tests/frontend/compiler/closure-skip-level.opt.wat
@@ -1515,7 +1515,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1582,7 +1582,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.load
@@ -1605,7 +1607,9 @@
   i64.store
   local.get $1
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   i32.const 8
   i32.const 5
   call $~lib/rt/itcms/__new
@@ -1637,8 +1641,8 @@
   i64.const 1
   i64.store
   local.get $1
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-skip-level.wat
+++ b/tests/frontend/compiler/closure-skip-level.wat
@@ -3074,7 +3074,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3105,7 +3105,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3113,6 +3113,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3163,7 +3166,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3171,6 +3174,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (local.set $y
    (i32.const 100)
@@ -3219,14 +3225,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-template.opt.wat
+++ b/tests/frontend/compiler/closure-template.opt.wat
@@ -1529,7 +1529,7 @@
   i64.store
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1590,7 +1590,9 @@
   call $~lib/rt/__newTuple
   local.tee $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1603,7 +1605,9 @@
   call $~lib/rt/__newTuple
   local.tee $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1735,8 +1739,8 @@
   i32.const 8
   call $~lib/rt/__newTuple
   local.tee $1
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   i32.add
@@ -1774,8 +1778,8 @@
   i32.const 8
   call $~lib/rt/__newTuple
   local.tee $1
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-template.wat
+++ b/tests/frontend/compiler/closure-template.wat
@@ -3077,7 +3077,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3108,7 +3108,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3116,6 +3116,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3163,14 +3166,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack
@@ -3248,7 +3249,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3256,6 +3257,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<f32>
@@ -3280,14 +3284,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<f32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-tmp-function.opt.wat
+++ b/tests/frontend/compiler/closure-tmp-function.opt.wat
@@ -1515,7 +1515,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1582,7 +1582,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1603,8 +1605,8 @@
   i64.const 1
   i64.store
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $0
   i32.const 4
   i32.add

--- a/tests/frontend/compiler/closure-tmp-function.wat
+++ b/tests/frontend/compiler/closure-tmp-function.wat
@@ -3075,7 +3075,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3106,7 +3106,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3114,6 +3114,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3163,14 +3166,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-two-funcs.opt.wat
+++ b/tests/frontend/compiler/closure-two-funcs.opt.wat
@@ -1516,7 +1516,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1607,8 +1607,8 @@
   local.get $1
   i32.store offset=4 align=1
   local.get $1
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   local.get $1
   i32.const 4
   i32.add
@@ -1803,7 +1803,9 @@
   i64.store
   local.get $1
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $1
   i32.load
   i32.const 4

--- a/tests/frontend/compiler/closure-two-funcs.wat
+++ b/tests/frontend/compiler/closure-two-funcs.wat
@@ -3074,7 +3074,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3105,7 +3105,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3113,6 +3113,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3161,7 +3164,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3169,6 +3172,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (i32.add
@@ -3197,14 +3203,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $1)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (call $~lib/tuple/SmallTuple#__set<i32>
    (call $~lib/rt/__tmptostack

--- a/tests/frontend/compiler/closure-use-before-assigned.opt.wat
+++ b/tests/frontend/compiler/closure-use-before-assigned.opt.wat
@@ -1515,7 +1515,7 @@
   memory.fill
   local.get $1
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $0 i32) (param $1 i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $0 i32) (param $1 i32)
   local.get $0
   local.get $1
   i32.store
@@ -1582,7 +1582,9 @@
   i64.store
   local.get $0
   global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
+  i32.const 0
+  global.set $~lib/rt/closure/env
   local.get $0
   i32.load
   i32.const 4
@@ -1617,8 +1619,8 @@
   local.get $0
   i32.store align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   i32.const 8
   i32.const 5
   call $~lib/rt/itcms/__new
@@ -1679,8 +1681,8 @@
   local.get $0
   i32.store offset=4 align=1
   local.get $0
-  global.get $~lib/rt/closure/env
-  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  i32.const 0
+  call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
   i32.const 8
   i32.const 5
   call $~lib/rt/itcms/__new

--- a/tests/frontend/compiler/closure-use-before-assigned.wat
+++ b/tests/frontend/compiler/closure-use-before-assigned.wat
@@ -3059,7 +3059,7 @@
    )
   )
  )
- (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple> (param $this i32) (param $offset i32) (param $value i32)
+ (func $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null> (param $this i32) (param $offset i32) (param $value i32)
   (local $elementPtr i32)
   (local.set $elementPtr
    (i32.add
@@ -3090,7 +3090,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3098,6 +3098,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3161,14 +3164,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (drop
    (local.tee $inner
@@ -3216,7 +3217,7 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
@@ -3224,6 +3225,9 @@
    (call $~lib/rt/__tmptostack
     (global.get $~lib/rt/closure/env)
    )
+  )
+  (global.set $~lib/rt/closure/env
+   (i32.const 0)
   )
   (return
    (call $~lib/tuple/SmallTuple#__get<i32>
@@ -3250,14 +3254,12 @@
     )
    )
   )
-  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple>
+  (call $~lib/tuple/SmallTuple#__set<~lib/tuple/SmallTuple|null>
    (call $~lib/rt/__tmptostack
     (local.get $0)
    )
    (i32.const 0)
-   (call $~lib/rt/__tmptostack
-    (global.get $~lib/rt/closure/env)
-   )
+   (i32.const 0)
   )
   (drop
    (local.tee $inner


### PR DESCRIPTION
The closure env global is a transient register for `call_indirect` that
is never cleared. Runtime→wasm calls leave a stale pointer
that the GC can free, causing use-after-free.

Emit `global.set $closure/env (i32.const 0)` to avoid this problem.