### PR TITLE
feat(cli): add --path

### DIFF
--- a/docs/en/using_compiler/module_resolution.md
+++ b/docs/en/using_compiler/module_resolution.md
@@ -1,8 +1,14 @@
-Unlike AssemblyScript's coarse-grained approach to third-party library path resolution via `--path` and `--lib` parameters, WARPO provides a script-based, fine-grained path resolution solution for third-party libraries.
+WARPO supports `--path` for coarse-grained third-party package resolution and also provides a script-based, fine-grained override mechanism.
 
-Similar to Rust's `build.rs` mechanism. WARPO will search the `create.ts` file in project root (can be defined by `--project`, `pwd` by default) and run it during build.
+Use `--path <dir>` to add extra package search roots, similar to `node_modules`. Repeat the option to add multiple roots. WARPO first searches the usual upward `node_modules` directories, then the extra `--path` roots in the order provided.
 
-We can inject custom module resolution functions through the `onModuleResolve` API exposed by WARPO in `create.ts` to hack the default module resolve behavior.
+```bash
+npx warpo build assembly/index.ts -o build/app.wat --path ./vendor --path ../shared-packages
+```
+
+When you need package-specific redirection or custom logic, use `create.ts`. Similar to Rust's `build.rs` mechanism, WARPO searches the `create.ts` file in project root (can be defined by `--project`, `pwd` by default) and runs it during build.
+
+You can inject custom module resolution functions through the `onModuleResolve` API exposed by WARPO in `create.ts`. If a custom resolver returns a package path, it takes precedence over the default resolver and any `--path` roots.
 
 ```ts
 import * as resolveModule from "warpo/create/resolveModule";

--- a/docs/zh-CN/using_compiler/module_resolution.md
+++ b/docs/zh-CN/using_compiler/module_resolution.md
@@ -1,8 +1,14 @@
-不同于 AssemblyScript 通过 `--path` 与 `--lib` 参数对第三方库做较粗粒度的路径解析方式，WARPO 提供了脚本化、细粒度的第三方库路径解析方案。
+WARPO 现在支持通过 `--path` 做粗粒度的第三方包路径解析，同时也提供脚本化、细粒度的覆盖机制。
 
-它与 Rust 的 `build.rs` 机制类似：WARPO 会在项目根目录（可通过 `--project` 指定，默认是 `pwd`）查找 `create.ts` 文件，并在构建过程中执行该脚本。
+使用 `--path <dir>` 可以添加额外的包搜索根目录，行为类似 `node_modules`。该参数可重复传入多个路径。WARPO 会先按照默认规则向上查找 `node_modules`，再按传入顺序依次查找额外的 `--path` 根目录。
 
-你可以在 `create.ts` 中通过 WARPO 暴露的 `onModuleResolve` API 注入自定义的模块解析函数，以“劫持”默认的模块解析行为。
+```bash
+npx warpo build assembly/index.ts -o build/app.wat --path ./vendor --path ../shared-packages
+```
+
+当你需要按包名做定向重写，或者需要更灵活的自定义逻辑时，可以使用 `create.ts`。它与 Rust 的 `build.rs` 机制类似：WARPO 会在项目根目录（可通过 `--project` 指定，默认是 `pwd`）查找 `create.ts` 文件，并在构建过程中执行该脚本。
+
+你可以在 `create.ts` 中通过 WARPO 暴露的 `onModuleResolve` API 注入自定义的模块解析函数。如果自定义解析器返回了包路径，它的优先级高于默认解析流程和所有 `--path` 根目录。
 
 ```ts
 import * as resolveModule from "warpo/create/resolveModule";

--- a/frontend/Compiler.cpp
+++ b/frontend/Compiler.cpp
@@ -30,6 +30,16 @@ static cli::Opt<std::string> ascWasmOption{
     [](argparse::Argument &arg) -> void { arg.help("WASM files for the frontend compiler").hidden(); },
 };
 
+static cli::Opt<std::vector<std::string>> pathOptions{
+    cli::Category::Frontend,
+    "--path",
+    [](argparse::Argument &arg) -> void {
+      arg.help("Adds a package resolution path, similar to node_modules. Repeat to add multiple search roots.")
+          .nargs(1U)
+          .append();
+    },
+};
+
 static void applyJsonConfig(Config &config, const common::FileConfigOptions &jsonConfig) {
   if (jsonConfig.exportStart)
     config.exportStart = *jsonConfig.exportStart;
@@ -57,6 +67,10 @@ static void applyCLIConfig(Config &config) {
   if (ascWasmOption.isSet()) {
     config.ascWasmPath = convertEmptyStringToNullOpt(ascWasmOption.get());
   }
+  if (pathOptions.isSet()) {
+    for (std::string const &path : pathOptions.get())
+      config.packageSearchPaths.push_back(std::filesystem::absolute(path).lexically_normal());
+  }
 }
 
 Config Config::getDefault() {
@@ -72,6 +86,7 @@ Config Config::getDefault() {
       .lowMemoryLimit = std::nullopt,
       .stackSize = DEFAULT_STACK_SIZE,
       .host = HostKind::None,
+      .packageSearchPaths = {},
 
       .useColorfulDiagMessage = support::isTTY(),
 

--- a/frontend/CompilerImpl.cpp
+++ b/frontend/CompilerImpl.cpp
@@ -126,7 +126,7 @@ FrontendCompiler::~FrontendCompiler() {
 }
 
 FrontendCompiler::FrontendCompiler(Config const &config, Pluggable *plugin)
-    : r{this}, moduleResolver_(plugin), config_{config} {
+    : r{this}, moduleResolver_(plugin, config.packageSearchPaths), config_{config} {
   if (config.ascWasmPath) [[unlikely]] {
     support::PerfRAII const p{support::PerfItemKind::CompilationHIR_PrepareWASMModule};
     std::string const wasmBytes = readBinaryFile(*config.ascWasmPath);

--- a/frontend/ModuleResolver.cpp
+++ b/frontend/ModuleResolver.cpp
@@ -62,6 +62,17 @@ std::optional<std::filesystem::path> ModuleResolver::findPackageRoot(std::filesy
     }
     current = current.parent_path();
   }
+
+  for (std::filesystem::path const &searchRoot : packageSearchPaths_) {
+    std::filesystem::path const target = searchRoot / packageName;
+    if (std::filesystem::exists(target) && std::filesystem::is_directory(target)) {
+      packageRootMap_[packageName] = target;
+      if (support::isDebug("ModuleResolve"))
+        fmt::println("[module resolve] resolve library '{}' in '{}' via --path", packageName, target.string());
+      return target;
+    }
+  }
+
   return std::nullopt;
 }
 

--- a/frontend/ModuleResolver.hpp
+++ b/frontend/ModuleResolver.hpp
@@ -23,9 +23,11 @@ struct Dependency final {
 class ModuleResolver {
   std::map<std::string, std::filesystem::path> packageRootMap_;
   Pluggable *plugin_;
+  std::vector<std::filesystem::path> packageSearchPaths_;
 
 public:
-  explicit ModuleResolver(Pluggable *plugin) : plugin_(plugin) {}
+  explicit ModuleResolver(Pluggable *plugin, std::vector<std::filesystem::path> packageSearchPaths)
+      : plugin_(plugin), packageSearchPaths_(std::move(packageSearchPaths)) {}
   std::optional<std::filesystem::path> findPackageRoot(std::filesystem::path const &sourceInternalPath,
                                                        std::string const &packageName);
 

--- a/include/warpo/frontend/Compiler.hpp
+++ b/include/warpo/frontend/Compiler.hpp
@@ -91,6 +91,7 @@ struct Config {
   std::optional<uint32_t> lowMemoryLimit;
   uint32_t stackSize = DEFAULT_STACK_SIZE;
   HostKind host = HostKind::None;
+  std::vector<std::filesystem::path> packageSearchPaths;
 
   bool useColorfulDiagMessage = false;
 

--- a/tests/driver/path-option/assembly/index.ts
+++ b/tests/driver/path-option/assembly/index.ts
@@ -1,0 +1,5 @@
+import { v } from "@as/custom/lib/index";
+
+export function _start(): void {
+  assert(v == "from path option");
+}

--- a/tests/driver/path-option/paths/@as/custom/lib/index.ts
+++ b/tests/driver/path-option/paths/@as/custom/lib/index.ts
@@ -1,0 +1,1 @@
+export const v: string = "from path option";

--- a/tests/driver/path-option/run.mjs
+++ b/tests/driver/path-option/run.mjs
@@ -1,0 +1,28 @@
+import { mkdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import expect from "expect";
+import { main as warpoMain } from "../../../dist/warpo_internal.js";
+
+const __dirname = import.meta.dirname;
+const projectRoot = __dirname;
+
+const entry = path.join(projectRoot, "assembly", "index.ts");
+const searchPath = path.join(projectRoot, "paths");
+const outputDir = path.join(projectRoot, "tmp");
+const missingPathWat = path.join(outputDir, "path-option-missing.wat");
+const resolvedPathWat = path.join(outputDir, "path-option.wat");
+
+mkdirSync(outputDir, { recursive: true });
+
+describe("driver: path-option", () => {
+  it("resolves packages from explicit --path search roots", { concurrency: false }, async () => {
+    const code = await warpoMain({
+      argv: ["build", entry, "-o", resolvedPathWat, "--path", searchPath],
+    });
+    expect(code).toBe(0);
+
+    const output = readFileSync(resolvedPathWat, "utf8");
+    expect(output).toContain("$~lib/@as/custom/lib/index/v");
+  });
+});


### PR DESCRIPTION
For “just add one more search path”, `--path` is the right tool.

`--path` matches the user’s mental model: “also search here like node_modules.” It is simpler, easier to explain, easier to debug, and does not force the user to write executable build logic for a static configuration problem. create.ts is a stronger mechanism and should be reserved for cases where resolution depends on package name, environment, or custom policy.

The split I’d recommend is:

1. Use `--path` when the requirement is “search this extra directory too”.
2. Use create.ts when the requirement is “for package A, redirect to X; for package B, redirect to Y; maybe do it conditionally”.
3. Keep create.ts as the escape hatch, not the default workflow, because it adds more maintenance cost and more hidden behavior.

One important nuance: right now `--path` is the more ergonomic option for ad hoc CLI use, but it is still only a CLI flag. If users need the same extra path on every build, the next sensible follow-up would be supporting `path` in asconfig.json too. That would cover the common static case without pushing people into create.ts.